### PR TITLE
Fixes completions err with jedi

### DIFF
--- a/prompt_toolkit/contrib/python_input.py
+++ b/prompt_toolkit/contrib/python_input.py
@@ -487,6 +487,8 @@ class PythonCompleter(Completer):
                 # Issue #43: UnicodeDecodeError on OpenBSD
                 # https://github.com/jonathanslenders/python-prompt-toolkit/issues/43
                 pass
+            except AttributeError:
+                pass
             else:
                 for c in completions:
                     yield Completion(c.name_with_symbols, len(c.complete) - len(c.name_with_symbols),


### PR DESCRIPTION
```a = (x for x in range(10))```
Then, as you type ```a(```, jedi complains as following:
```
In [1]: a=(x for x in range(10)) 

In [2]: a(Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/site-packages/jedi/cache.py", line 137, in wrap
    return getattr(self, name)
AttributeError: 'LazyName' object has no attribute '_parent'
 ~
During handling of the above exception, another exception occurred:r] Execute > 

Traceback (most recent call last):
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/compiled/__init__.p
    return evaluator.compiled_cache[key][0]
KeyError: (4511290496, 4510349128, 4510349128)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3
    self.run()
  File "/usr/local/lib/python3.4/site-packages/prompt_toolkit/eventloop/base.py"
    callback()
  File "/usr/local/lib/python3.4/site-packages/prompt_toolkit/__init__.py", line
    completions = list(line.completer.get_completions(document))
  File "/usr/local/lib/python3.4/site-packages/prompt_toolkit/contrib/python_inp
    completions = script.completions()
  File "/usr/local/lib/python3.4/site-packages/jedi/api/__init__.py", line 161, 
    for call_sig in self.call_signatures():
  File "/usr/local/lib/python3.4/site-packages/jedi/api/__init__.py", line 574, 
    self._pos, user_stmt)
  File "/usr/local/lib/python3.4/site-packages/jedi/cache.py", line 90, in wrapp
    value = optional_callable()
  File "/usr/local/lib/python3.4/site-packages/jedi/api/__init__.py", line 572, 
    _callable = lambda: self._evaluator.eval_call(stmt_el)
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/__init__.py", line 
    return self.eval_call_path(path, par, s.start_pos)
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/__init__.py", line 
    search_global=True)
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/__init__.py", line 
    return f.find(scopes, resolve_decorator, search_global)
  File "/usr/local/lib/python3.4/site-packages/jedi/debug.py", line 51, in wrapp
    result = func(*args, **kwargs)
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/finder.py", line 46
    names = self.filter_name(scopes)
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/finder.py", line 89
    scope = name.parent.parent
  File "/usr/local/lib/python3.4/site-packages/jedi/cache.py", line 139, in wrap
    result = func(self)
  File "/usr/local/lib/python3.4/site-packages/jedi/api/interpreter.py", line 97
    return compiled.create(self._evaluator, self._value, module, module)
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/compiled/__init__.p
    result = func(evaluator, obj, parent, module)
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/compiled/__init__.p
    faked = fake.get_faked(module and module.obj, obj)
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/compiled/fake.py", 
    result = _faked(module, obj, name)
  File "/usr/local/lib/python3.4/site-packages/jedi/evaluate/compiled/fake.py", 
    cls = search_scope(faked_mod, obj.__objclass__.__name__)
AttributeError: 'generator' object has no attribute '__objclass__'
```
There should be one way to handle various syntax errors which jedi complains at.