### PR TITLE
Add C-Up/Down/Left/Right keys

### DIFF
--- a/prompt_toolkit/key_binding/bindings/emacs.py
+++ b/prompt_toolkit/key_binding/bindings/emacs.py
@@ -216,6 +216,7 @@ def load_emacs_bindings(registry, filter=None):
         pass
 
     @handle(Keys.Escape, 'f')
+    @handle(Keys.ControlRight)
     def _(event):
         """
         Cursor to end of next word.
@@ -227,6 +228,7 @@ def load_emacs_bindings(registry, filter=None):
             buffer.cursor_position += pos
 
     @handle(Keys.Escape, 'b')
+    @handle(Keys.ControlLeft)
     def _(event):
         """
         Cursor to start of previous word.

--- a/prompt_toolkit/keys.py
+++ b/prompt_toolkit/keys.py
@@ -52,6 +52,10 @@ class Keys(object):
     ControlSquareClose = Key('<C-SquareClose>')
     ControlCircumflex  = Key('<C-Circumflex>')
     ControlUnderscore  = Key('<C-Underscore>')
+    ControlLeft        = Key('<C-Left>')
+    ControlRight       = Key('<C-Right>')
+    ControlUp          = Key('<C-Up>')
+    ControlDown        = Key('<C-Down>')
 
     Up          = Key('<Up>')
     Down        = Key('<Down>')

--- a/prompt_toolkit/terminal/vt100_input.py
+++ b/prompt_toolkit/terminal/vt100_input.py
@@ -128,6 +128,14 @@ class InputStream(object):
         '\x1b[32~': Keys.F18,
         '\x1b[33~': Keys.F19,
         '\x1b[34~': Keys.F20,
+        '\x1b[1;5D': Keys.ControlLeft,   # Cursor Mode
+        '\x1b[1;5C': Keys.ControlRight,  # Cursor Mode
+        '\x1b[1;5A': Keys.ControlUp,     # Cursor Mode
+        '\x1b[1;5B': Keys.ControlDown,   # Cursor Mode
+        '\x1bOD': Keys.ControlLeft,     # Application Mode (tmux)
+        '\x1bOC': Keys.ControlRight,    # Application Mode (tmux)
+        '\x1bOA': Keys.ControlUp,       # Application Mode (tmux)
+        '\x1bOB': Keys.ControlDown,     # Application Mode (tmux)
 
         # Meta + arrow keys. Several terminals handle this differently.
         # The following sequences are for xterm and gnome-terminal.


### PR DESCRIPTION
This change adds 4 more new key codes. C-Left, C-Right, C-Up and C-Down. 

It also adds C-Left and C-Right for Prev word and Next word in emacs bindings.

I've tested this change both with and without Tmux (which exercises the Application mode in tmux and Cursor mode outside of tmux). 

This change is currently targeted for VT100 only, since I don't have a windows machine to try and find the equivalent keycode in win32 console.