### PR TITLE
Fix jedi dependency to work withing the new PEP-440 rules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         packages=find_packages('.'),
         install_requires = [
             'docopt',
-            'jedi>=0.8.1',
+            'jedi>=0.8.1-final0',
             'pygments',
             'six>=1.8.0',
             'wcwidth',


### PR DESCRIPTION
PEP-440 is implemented in pip 6.0.

Fixes #72.