### PR TITLE
Align lines of eval output to the 1st line in repl

### DIFF
--- a/prompt_toolkit/contrib/repl.py
+++ b/prompt_toolkit/contrib/repl.py
@@ -113,16 +113,23 @@ class PythonRepl(PythonCommandLineInterface):
                 locals = self.get_locals()
                 locals['_'] = locals['_%i' % self.current_statement_index] = result
 
+                out_mark = 'Out[%i]: ' % self.current_statement_index
+
                 if result is not None:
                     try:
-                        self.stdout.write('Out[%i]: %r\n' % (self.current_statement_index, result))
+                        result_str = '%r\n' % result
                     except UnicodeDecodeError:
                         # In Python 2: `__repr__` should return a bytestring,
                         # so to put it in a unicode context could raise an
                         # exception that the 'ascii' codec can't decode certain
                         # characters. Decode as utf-8 in that case.
-                        self.stdout.write('Out[%i]: %s\n' % (self.current_statement_index, repr(result).decode('utf-8')))
+                        result_str = '%s\n' % repr(result).decode('utf-8')
 
+                # align every line to the first one
+                line_sep = '\n' + ' ' * len(out_mark)
+                out_string = out_mark + line_sep.join(result_str.splitlines())
+
+                self.stdout.write(out_string)
             # If not a valid `eval` expression, run using `exec` instead.
             except SyntaxError:
                 exec_(line, self.get_globals(), self.get_locals())


### PR DESCRIPTION
Hi,
Currently the lines in the `Out` blocks are not aligned, causing of an object with multi-line `repr` appear like this:
```python
In [1]: import numpy

In [2]: numpy.arange(16).reshape(4,4)
Out[2]: array([[ 0,  1,  2,  3],
       [ 4,  5,  6,  7],
       [ 8,  9, 10, 11],
       [12, 13, 14, 15]])

```

This PR makes the lines in the `Out` blocks aligned to the first one.

```python
In [1]: class MultilineRepr:
     2.     def __repr__(self):
     3.         return "three\nline\nrepr"  

In [2]: MultilineRepr()
Out[2]: three
        line
        repr
```