### PR TITLE
Fixed tuple repr bug in relp

### DIFF
--- a/prompt_toolkit/contrib/repl.py
+++ b/prompt_toolkit/contrib/repl.py
@@ -117,7 +117,7 @@ class PythonRepl(PythonCommandLineInterface):
 
                 if result is not None:
                     try:
-                        result_str = '%r\n' % result
+                        result_str = '%r\n' % (result, )
                     except UnicodeDecodeError:
                         # In Python 2: `__repr__` should return a bytestring,
                         # so to put it in a unicode context could raise an


### PR DESCRIPTION
My previous pull request ( #88  ) contained a bug I overlooked, this one fixes it.
The bug was due to missing parentheses in string formatting:
```python
>>> "%r" % (1,2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not all arguments converted during string formatting
```

