### PR TITLE
Add support for tox (http://tox.testrun.org/)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: python
-
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "pypy"
-  - "pypy3"
-
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=pypy
+  - TOXENV=pypy3
 install:
-  - "pip install . --use-mirrors"
-
-script: cd tests; ./run_tests.py
+  - travis_retry pip install tox
+script:
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py33, py34, pypy, pypy3
+
+[testenv]
+commands = {toxinidir}/tests/run_tests.py


### PR DESCRIPTION
Add tox.ini for tox (http://tox.testrun.org)

tox: http://tox.testrun.org/

    $ pip install tox
    ...
    $ tox
    ...
      py26: commands succeeded
      py27: commands succeeded
      py33: commands succeeded
      py34: commands succeeded
      pypy: commands succeeded
      pypy3: commands succeeded
      congratulations :)

Cc: @RonnyPfannschmidt, @antocuni