### PR TITLE
(Work in progress) Flush vt100 input after timeout.

### DIFF
--- a/prompt_toolkit/eventloop/asyncio_posix.py
+++ b/prompt_toolkit/eventloop/asyncio_posix.py
@@ -31,7 +31,7 @@ class PosixAsyncioEventLoop(BaseAsyncioEventLoop):
     def wait_for_input(self, f_ready):
         def stdin_ready():
             data = self._read_from_stdin()
-            self._inputstream.feed_and_flush(data)
+            self._inputstream.feed(data)
 
             f_ready.set_result(None)  # Quit coroutine
             self.loop.remove_reader(self.stdin.fileno())

--- a/prompt_toolkit/eventloop/posix.py
+++ b/prompt_toolkit/eventloop/posix.py
@@ -51,7 +51,7 @@ class PosixEventLoop(BaseEventLoop):
             if self.stdin in r:
                 # Feed input text.
                 data = self._read_from_stdin()
-                self.inputstream.feed_and_flush(data)
+                self.inputstream.feed(data)
                 return
 
             # If we receive something on our "call_from_executor" pipe, process
@@ -65,6 +65,10 @@ class PosixEventLoop(BaseEventLoop):
                 for c in calls_from_executor:
                     c()
             else:
+                # When an input timeout occured, always flush the VT100
+                # inputstream.
+                self.inputstream.flush()  # TODO: Shouldn't we always request a redraw after flush???
+
                 # Fire input timeout event.
                 self.onInputTimeout.fire()
                 timeout = None


### PR DESCRIPTION
This should fix some issues with "playitagainsam" and Cygwin.

It's work in progress.