### PR TITLE
Fixing bug with default message in get_input()

### DIFF
--- a/prompt_toolkit/shortcuts.py
+++ b/prompt_toolkit/shortcuts.py
@@ -115,7 +115,7 @@ def create_default_layout(message='', lexer=None, is_password=False,
     if extra_input_processors:
         input_processors.extend(extra_input_processors)
 
-    if message:
+    if get_prompt_tokens is None:
         input_processors.append(DefaultPrompt.from_message(message))
     else:
         input_processors.append(DefaultPrompt(get_prompt_tokens))


### PR DESCRIPTION
Following code stopped working after last commit introducing `get_prompt_tokens` in `create_default_layout`:
```
from prompt_toolkit.shortcuts import get_input

if __name__ == '__main__':
    answer = get_input()
    print('You said: %s' % answer)
```
Because when message is empty (`''`) then code assumes that there is `get_prompt_tokens` function, which is not always true.

This is a very simple fix for this issue.