### PR TITLE
Fix AssertionError in the layout example

### DIFF
--- a/examples/layout.py
+++ b/examples/layout.py
@@ -88,7 +88,7 @@ def main():
             Window(content=BufferControl(lexer=PythonLexer,
                                          show_line_numbers=Always(),
                                          input_processors=[
-                                                DefaultPrompt('python> '),
+                                                DefaultPrompt.from_message('python> '),
                                                 AfterInput.static(' <python', token=Token.AfterInput),
                                          ]),
             ),


### PR DESCRIPTION
When I try to run the layout example(layout.py), I get an error below.

```
Traceback (most recent call last):
  File "layout.py", line 144, in <module>
    main()
  File "layout.py", line 91, in main
    DefaultPrompt('python> '),
  File "/usr/lib/python3.4/site-packages/prompt_toolkit/layout/prompt.py", line 34, in __init__
    assert callable(get_tokens)
AssertionError
```

If it wants to gives only a message on initialization of `DefaultPrompt`, it should use `DefaultPrompt.from_message` instead. 