### PR TITLE
Add Ctrl-A & Ctrl-E support in vim insert mode.

### DIFF
--- a/prompt_toolkit/key_binding/bindings/vi.py
+++ b/prompt_toolkit/key_binding/bindings/vi.py
@@ -574,6 +574,22 @@ def load_vi_bindings(registry, vi_state, filter=None):
         # TODO: go to end of sentence.
         pass
 
+    @handle(Keys.ControlA, filter=insert_mode)
+    def _(event):
+        """
+        Move to first non whitespace of current line
+        """
+        buffer = event.current_buffer
+        buffer.cursor_position += buffer.document.get_start_of_line_position(after_whitespace=True)
+
+    @handle(Keys.ControlE, filter=insert_mode)
+    def _(event):
+        """
+        Move to last charater of current line
+        """
+        buffer = event.current_buffer
+        buffer.cursor_position += buffer.document.get_end_of_line_position()
+
     def change_delete_move_yank_handler(*keys, **kw):
         """
         Register a change/delete/move/yank handlers. e.g.  'dw'/'cw'/'w'/'yw'

--- a/prompt_toolkit/key_binding/bindings/vi.py
+++ b/prompt_toolkit/key_binding/bindings/vi.py
@@ -574,7 +574,7 @@ def load_vi_bindings(registry, vi_state, filter=None):
         # TODO: go to end of sentence.
         pass
 
-    @handle(Keys.ControlA, filter=insert_mode)
+    @handle(Keys.ControlA, filter=insert_mode|selection_mode)
     def _(event):
         """
         Move to first non whitespace of current line
@@ -582,7 +582,7 @@ def load_vi_bindings(registry, vi_state, filter=None):
         buffer = event.current_buffer
         buffer.cursor_position += buffer.document.get_start_of_line_position(after_whitespace=True)
 
-    @handle(Keys.ControlE, filter=insert_mode)
+    @handle(Keys.ControlE, filter=insert_mode|selection_mode)
     def _(event):
         """
         Move to last charater of current line


### PR DESCRIPTION
These are shortcuts for home & end when in insert mode in vim. If your
keyboard doesn't have actual home and end keys, these are the only way
(that I know) to get to start/end of line without exiting insert mode.