### PR TITLE
Add 'M' keybinding to vi bindings.

### DIFF
--- a/prompt_toolkit/key_binding/bindings/vi.py
+++ b/prompt_toolkit/key_binding/bindings/vi.py
@@ -954,6 +954,7 @@ def load_vi_bindings(registry, vi_state, filter=None):
         return CursorRegion(pos)
 
     @handle('z', '+', filter=navigation_mode|selection_mode)
+    @handle('z', Keys.ControlJ, filter=navigation_mode|selection_mode)
     def _(event):
         """
         Scrolls the window to makes the current line the first line in the visible region.

--- a/prompt_toolkit/key_binding/bindings/vi.py
+++ b/prompt_toolkit/key_binding/bindings/vi.py
@@ -912,6 +912,27 @@ def load_vi_bindings(registry, vi_state, filter=None):
             pos = -len(b.document.text_before_cursor)
         return CursorRegion(pos)
 
+    @change_delete_move_yank_handler('M')
+    def _(event):
+        """
+        Moves cursor to the vertical center of the visible region.
+        Implements 'cM', 'dM', 'M'.
+        """
+        w = find_window_for_buffer_name(event.cli.layout, event.cli.current_buffer_name)
+        b = event.current_buffer
+
+        if w:
+            # When we find a Window that has BufferControl showing this window,
+            # move to the center of the visible area.
+            pos = (b.document.translate_row_col_to_index(
+                       w.render_info.center_visible_line(), 0) -
+                   b.cursor_position)
+
+        else:
+            # Otherwise, move to the start of the input.
+            pos = -len(b.document.text_before_cursor)
+        return CursorRegion(pos)
+
     @change_delete_move_yank_handler('L')
     def _(event):
         """

--- a/prompt_toolkit/key_binding/bindings/vi.py
+++ b/prompt_toolkit/key_binding/bindings/vi.py
@@ -953,6 +953,41 @@ def load_vi_bindings(registry, vi_state, filter=None):
             pos = len(b.document.text_after_cursor)
         return CursorRegion(pos)
 
+    @handle('z', '+', filter=navigation_mode|selection_mode)
+    def _(event):
+        """
+        Scrolls the window to makes the current line the first line in the visible region.
+        """
+        w = find_window_for_buffer_name(event.cli.layout, event.cli.current_buffer_name)
+        b = event.cli.current_buffer
+
+        if w and w.render_info:
+            # Calculate the offset that we need in order to position the row
+            # containing the cursor in the center.
+            cursor_position_row = b.document.cursor_position_row
+
+            render_row = w.render_info.input_line_to_screen_line(cursor_position_row)
+            if render_row is not None:
+                w.vertical_scroll = max(0, render_row)
+
+
+    @handle('z', '-', filter=navigation_mode|selection_mode)
+    def _(event):
+        """
+        Scrolls the window to makes the current line the last line in the visible region.
+        """
+        w = find_window_for_buffer_name(event.cli.layout, event.cli.current_buffer_name)
+        b = event.cli.current_buffer
+
+        if w and w.render_info:
+            # Calculate the offset that we need in order to position the row
+            # containing the cursor in the center.
+            cursor_position_row = b.document.cursor_position_row
+
+            render_row = w.render_info.input_line_to_screen_line(cursor_position_row)
+            if render_row is not None:
+                w.vertical_scroll = max(0, (render_row - w.render_info.rendered_height))
+
     @handle('z', 'z', filter=navigation_mode|selection_mode)
     def _(event):
         """

--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -463,6 +463,16 @@ class WindowRenderInfo(object):
 
         return 0
 
+    def center_visible_line(self, before_scroll_offset=False,
+            after_scroll_offset=False):
+        """
+        Like `first_visible_line`, but for the center visible line.
+        """
+        return (self.first_visible_line(after_scroll_offset) +
+                (self.last_visible_line(before_scroll_offset) -
+                    self.first_visible_line(after_scroll_offset))/2
+                )
+
     @property
     def full_height_visible(self):
         """


### PR DESCRIPTION
This adds the 'M' keybinding, which moves the cursor to the vertical center of the rendered lines in a buffer. 

It also adds 'z-' and 'z+' bindings. 

The end goal is to have this keybinding available in pyvim. 