### PR TITLE
Revise the typical usage of Renderer

### DIFF
--- a/prompt_toolkit/renderer.py
+++ b/prompt_toolkit/renderer.py
@@ -179,7 +179,8 @@ class Renderer(object):
 
     ::
 
-        r = Renderer(sys.stdout)
+        output = Vt100_Output.from_pty(sys.stdout)
+        r = Renderer(output)
         r.render(cli, layout=..., style=...)
     """
     def __init__(self, output, use_alternate_screen=False):  # XXX: implement alternate screen for Windows.


### PR DESCRIPTION
`sys.stdout` is not an instance of `Output`.