### PR TITLE
Correct emulation of Emacs' C-t (transpose-char) behavior.

### DIFF
--- a/prompt_toolkit/key_binding/bindings/basic.py
+++ b/prompt_toolkit/key_binding/bindings/basic.py
@@ -197,7 +197,7 @@ def load_basic_bindings(registry, filter=Always()):
             return
         elif p == len(b.text) or b.text[p] == '\n':
             b.swap_characters_before_cursor()
-        elif b.document.get_start_of_line_position:
+        else:
             b.cursor_position += b.document.get_cursor_right_position()
             b.swap_characters_before_cursor()
 

--- a/prompt_toolkit/key_binding/bindings/basic.py
+++ b/prompt_toolkit/key_binding/bindings/basic.py
@@ -185,7 +185,21 @@ def load_basic_bindings(registry, filter=Always()):
 
     @handle(Keys.ControlT, filter= ~has_selection)
     def _(event):
-        event.current_buffer.swap_characters_before_cursor()
+        """
+        Emulate Emacs transpose-char behavior: at the beginning of the buffer,
+        do nothing.  At the end of a line or buffer, swap the characters before
+        the cursor.  Otherwise, move the cursor right, and then swap the
+        characters before the cursor.
+        """
+        b = event.current_buffer
+        p = b.cursor_position
+        if p == 0:
+            return
+        elif p == len(b.text) or b.text[p] == '\n':
+            b.swap_characters_before_cursor()
+        elif b.document.get_start_of_line_position:
+            b.cursor_position += b.document.get_cursor_right_position()
+            b.swap_characters_before_cursor()
 
     @handle(Keys.ControlU, filter= ~has_selection)
     def _(event):


### PR DESCRIPTION
This addresses my concern in issue #129.  I tested this with single and multiline input using the examples, and everything behaves as expected.  However, if there's a standard way to test these things, I can add unit tests too.