### PR TITLE
Use call_soon_threadsafe() in call_from_executor().

### DIFF
--- a/prompt_toolkit/eventloop/asyncio_posix.py
+++ b/prompt_toolkit/eventloop/asyncio_posix.py
@@ -100,4 +100,4 @@ class PosixAsyncioEventLoop(EventLoop):
         Call this function in the main event loop.
         Similar to Twisted's ``callFromThread``.
         """
-        self.loop.call_soon(callback)
+        self.loop.call_soon_threadsafe(callback)

--- a/prompt_toolkit/eventloop/asyncio_win32.py
+++ b/prompt_toolkit/eventloop/asyncio_win32.py
@@ -71,4 +71,4 @@ class Win32AsyncioEventLoop(EventLoop):
         self.loop.run_in_executor(None, callback)
 
     def call_from_executor(self, callback):
-        self.loop.call_soon(callback)
+        self.loop.call_soon_threadsafe(callback)


### PR DESCRIPTION
`call_from_executor()` is inteded to be called from a different thread. Thus use the threadsafe version of `call_soon()`: [`call_soon_threadsafe()`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.BaseEventLoop.call_soon_threadsafe).