### PR TITLE
Fixed TypeError when closing ptpython, when started from within CERN's ROOT package

### DIFF
--- a/prompt_toolkit/eventloop/posix.py
+++ b/prompt_toolkit/eventloop/posix.py
@@ -227,4 +227,7 @@ class call_on_sigwinch(object):
         self.previous_callback = signal.signal(signal.SIGWINCH, lambda *a: self.callback())
 
     def __exit__(self, *a, **kw):
-        signal.signal(signal.SIGWINCH, self.previous_callback)
+        if self.previous_callback is None:
+            signal.signal(signal.SIGWINCH, 0)
+        else:
+            signal.signal(signal.SIGWINCH, self.previous_callback)


### PR DESCRIPTION
To reproduce, compile and run the ROOT package from https://root.cern.ch.

Expected behavior:
```
bash> root -l
root [0] TPython::Prompt()
>>> import ptpython.repl
>>> python.repl.embed()
>>> # In ptpython, Ctrl-D to exit
>>> # Back in normal python prompt
```

Observed behavior:
```
bash> root -l
root [0] TPython::Prompt()
>>> import ptpython.repl
>>> python.repl.embed()
>>> # In ptpython, Ctrl-D to exit
Traceback (most recent call last):
  File "", line 1, in <module>

  File "/user/lunderbe/.local/lib/python2.7/site-packages/ptpython/repl.py", line 305, in embed
      cli.run()
        File "/user/lunderbe/.local/lib/python2.7/site-packages/prompt_toolkit/interface.py", line 325, in run
            self.eventloop.run(self.input, self.create_eventloop_callbacks())
              File "/user/lunderbe/.local/lib/python2.7/site-packages/prompt_toolkit/eventloop/posix.py", line 112, in run
                  current_timeout = None
                    File "/user/lunderbe/.local/lib/python2.7/site-packages/prompt_toolkit/eventloop/posix.py", line 199, in __exit__
                        signal.signal(signal.SIGWINCH, self.previous_callback)
                        TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object
```

