### PR TITLE
Vi movement bindings 't' and 'f' were off by one.

### DIFF
--- a/prompt_toolkit/key_binding/bindings/vi.py
+++ b/prompt_toolkit/key_binding/bindings/vi.py
@@ -839,7 +839,7 @@ def load_vi_bindings(registry, vi_state, enable_visual_key=Always(), filter=None
         """
         vi_state.last_character_find = CharacterFind(event.data, False)
         match = event.current_buffer.document.find(event.data, in_current_line=True, count=event.arg)
-        return CursorRegion(match or 0)
+        return CursorRegion((match + 1) if match else 0)
 
     @change_delete_move_yank_handler('F', Keys.Any)
     def _(event):
@@ -857,7 +857,7 @@ def load_vi_bindings(registry, vi_state, enable_visual_key=Always(), filter=None
         """
         vi_state.last_character_find = CharacterFind(event.data, False)
         match = event.current_buffer.document.find(event.data, in_current_line=True, count=event.arg)
-        return CursorRegion(match - 1 if match else 0)
+        return CursorRegion(match or 0)
 
     @change_delete_move_yank_handler('T', Keys.Any)
     def _(event):


### PR DESCRIPTION
Ref: https://github.com/dbcli/mycli/issues/167

'dt' and 'df' are off by one in the Vi mode. 