### PR TITLE
Use singleton object for Float x/ycursor

### DIFF
--- a/prompt_toolkit/shortcuts.py
+++ b/prompt_toolkit/shortcuts.py
@@ -29,7 +29,7 @@ from .history import InMemoryHistory
 from .interface import CommandLineInterface, Application, AbortAction, AcceptAction
 from .key_binding.manager import KeyBindingManager
 from .layout import Window, HSplit, VSplit, FloatContainer, Float
-from .layout.containers import ConditionalContainer
+from .layout.containers import ConditionalContainer, cursor
 from .layout.controls import BufferControl, TokenListControl
 from .layout.dimension import LayoutDimension
 from .layout.lexers import PygmentsLexer
@@ -274,8 +274,8 @@ def create_prompt_layout(message='', lexer=None, is_password=False,
                               scroll_offset=1,
                               extra_filter=HasFocus(DEFAULT_BUFFER) &
                                            ~display_completions_in_columns)),
-                    Float(xcursor=True,
-                          ycursor=True,
+                    Float(left=cursor,
+                          top=cursor,
                           content=MultiColumnCompletionsMenu(
                               extra_filter=HasFocus(DEFAULT_BUFFER) &
                                            display_completions_in_columns,


### PR DESCRIPTION
Attempt to start implementing #182

-- 
I'm not familiar with the codebase so it might not be he right way to do that, 
I suppose the all logic here could be simplified and keep backward compat with `(x|y)cursor`

Screenshot with this as a completer:
```
Float(left=cursor+7,
       top=cursor-1,
                      ...))
```

<img width="455" alt="screen shot 2015-11-03 at 20 48 48" src="https://cloud.githubusercontent.com/assets/335567/10929749/7395ca4c-826c-11e5-9b7d-7669df1040ed.png">


(note, my goal is to have a completer like Fish which is a `cursor.y+1` but the all width of terminal in the end, but not really a hsplit)