### PR TITLE
Moved example to using Python 3.5 for asyncio

### DIFF
--- a/examples/asyncio-prompt.py
+++ b/examples/asyncio-prompt.py
@@ -31,10 +31,7 @@ async def print_counter():
     while True:
         print('Counter: %i' % i)
         i += 1
-        try:
-            await asyncio.sleep(3)
-        except asyncio.CancelledError:
-            return
+        await asyncio.sleep(3)
 
 
 async def interactive_shell():
@@ -64,12 +61,14 @@ async def interactive_shell():
 
 
 def main():
-    counter = loop.create_task(print_counter())
     shell = loop.create_task(interactive_shell())
+
+    # This gathers all the async calls, so they can be cancelled at once
+    tasks = asyncio.gather(print_counter(), return_exceptions=True)
     
     loop.run_until_complete(shell)
-    counter.cancel()
-    loop.run_until_complete(counter)
+    tasks.cancel()
+    loop.run_until_complete(tasks)
     print('Qutting event loop. Bye.')
     loop.close()
 


### PR DESCRIPTION
This updates the example to use new syntax in Python 3.5, and the new names included in Python 3.5 and Python 3.4.4.

Using `async` and `await`, and removed warnings and depreciated functions (like `asyncio.async`), and minor cleanup (since example cannot be run in older Pythons anyway)