### PR TITLE
Respect _StdoutProxy.raw when flushing

### DIFF
--- a/prompt_toolkit/interface.py
+++ b/prompt_toolkit/interface.py
@@ -886,7 +886,10 @@ class _StdoutProxy(object):
     def _flush(self):
         def run():
             for s in self._buffer:
-                self._cli.output.write(s)
+                if self._raw:
+                    self._cli.output.write_raw(s)
+                else:
+                    self._cli.output.write(s)
             self._buffer = []
             self._cli.output.flush()
         self._do(run)


### PR DESCRIPTION
Hi, the new `_StdoutProxy.raw` is a really useful feature. It should also be respected when flushing the buffer.