### PR TITLE
Add additional aliases for backward compatibility

### DIFF
--- a/prompt_toolkit/shortcuts.py
+++ b/prompt_toolkit/shortcuts.py
@@ -520,3 +520,7 @@ def prompt_async(message='', **kwargs):
 
 # Deprecated alias for `prompt`.
 get_input = prompt
+# Deprecated alias for create_default_layout
+create_default_layout = create_prompt_layout
+# Deprecated alias for create_default_application
+create_default_application = create_prompt_application


### PR DESCRIPTION
Added:
create_default_layout = create_prompt_layout
create_default_application = create_prompt_application
in prompt_toolkit/shortcuts.py

Note: Based on my searching of the code in the Debian archive, I think this will make 0.54 compatible with the existing prompt based applications that are packaged.