### PR TITLE
setup.py - add trove classifiers and version parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import re
 from setuptools import setup, find_packages
 
 
@@ -11,13 +12,22 @@ long_description = open(
 ).read()
 
 
-version = '0.57'  # Don't forget to update in prompt_toolkit.__init__!
+def get_version(package):
+    """
+    Return package version as listed in `__version__` in `__init__.py`.
+    """
+    path = os.path.join(os.path.dirname(__file__), package, '__init__.py')
+    with open(path) as f:
+        init_py = f.read()
+    return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
+
+
+version = get_version('prompt_toolkit')
 
 setup(
     name='prompt_toolkit',
     author='Jonathan Slenders',
     version=version,
-    license='LICENSE.txt',
     url='https://github.com/jonathanslenders/python-prompt-toolkit',
     description='Library for building powerful interactive command lines in Python',
     long_description=long_description,
@@ -26,5 +36,19 @@ setup(
         'pygments',
         'six>=1.9.0',
         'wcwidth',
+    ],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
     ],
 )


### PR DESCRIPTION
Found that `prompt_toolkit` is not listed as Python 3 compatible by `caniusepython3`, because it's lacking Trove Classifiers. Added them. Due to adding a License Trove Classifier, it's no longer necessary to provide the `license` argument to `setup`.

Whilst I was at it I saw you have the version defined in two files with a comment to remind you about updating both. I have adapted some code I use on a number of projects to ease this burden so the version is only stored in `__init__`.