### PR TITLE
update link to cmder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ possible". Both Unix and Windows terminals have their limitations. But in
 general, the Unix experience will still be a little better.
 
 For Windows, it's recommended to use either `cmder
-<http://gooseberrycreative.com/cmder/>`_ or `conemu <https://conemu.github.io/>`_.
+<http://cmder.net/>`_ or `conemu <https://conemu.github.io/>`_.
 
 
 Installation


### PR DESCRIPTION
maybe the github repo could also be an alternative https://github.com/cmderdev/cmder

I'm not 100% of the link, but the 404 current one is probably wrong