### PR TITLE
Add softlayer python to list of prompt-toolkit users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,7 @@ Shells:
 - `crash <https://github.com/crate/crash>`_:  Crate command line client.
 - `vcli <https://github.com/dbcli/vcli>`_: Vertica client.
 - `aws-shell <https://github.com/awslabs/aws-shell>`_: An integrated shell for working with the AWS CLI.
+- `softlayer-python <https://github.com/softlayer/softlayer-python>`_: A command-line interface to manage various SoftLayer products and services.
 
 Full screen applications:
 


### PR DESCRIPTION
This is the only user of prompt-toolkit that's packaged in Debian that wasn't already listed.