### PR TITLE
Fixed examples/autocompletion.py

### DIFF
--- a/examples/autocompletion.py
+++ b/examples/autocompletion.py
@@ -3,8 +3,8 @@
 Autocompletion example.
 
 Press [Tab] to complete the current word.
-- The first Tab press fills in the common part of all completions.
-- The second Tab press shows all the completions. (In the menu)
+- The first Tab press fills in the common part of all completions
+    and shows all the completions. (In the menu)
 - Any following tab press cycles through all the possible completions.
 """
 from __future__ import unicode_literals
@@ -50,7 +50,8 @@ animal_completer = WordCompleter([
 
 
 def main():
-    text = prompt('Give some animals: ', completer=animal_completer)
+    text = prompt('Give some animals: ', completer=animal_completer,
+                  complete_while_typing=False)
     print('You said: %s' % text)
 
 


### PR DESCRIPTION
Fixes the issue described in #206 (somewhat).

I've added `completion_while_typing=False` to mostly match the module docstring, then updated it to describe what the actual behavior currently is.

Things I'm still unsure about:
* Is there a way to get the behavior described in the docstring as it was?
* Is there an option to insert a space after a full match? Currently the cursor sticks to the end of the word and the menu shows just that one option.