### PR TITLE
Disable bracketed paste support in ConEmu

### DIFF
--- a/prompt_toolkit/terminal/conemu_output.py
+++ b/prompt_toolkit/terminal/conemu_output.py
@@ -32,7 +32,8 @@ class ConEmuOutput(object):
     def __getattr__(self, name):
         if name in ('get_size', 'get_rows_below_cursor_position',
                     'enable_mouse_support', 'disable_mouse_support',
-                    'scroll_buffer_to_prompt', 'get_win32_screen_buffer_info'):
+                    'scroll_buffer_to_prompt', 'get_win32_screen_buffer_info',
+                    'enable_bracketed_paste', 'disable_bracketed_paste):
             return getattr(self.win32_output, name)
         else:
             return getattr(self.vt100_output, name)


### PR DESCRIPTION
ConEmu supports bracketed paste but prompt-toolkit does not process bracketed pastes on Windows properly so disable it.

This patch fixes the issue where you get `[200~` and `[201~` around pasted strings when using ConEmu.