### PR TITLE
Improve the documentation for beginers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Python Prompt Toolkit
 and terminal applications in Python.
 
 Read the `documentation on readthedocs
-<http://python-prompt-toolkit.readthedocs.org/en/latest/>`_.
+<http://python-prompt-toolkit.readthedocs.org/en/stable/>`_.
 
 
 Ptpython

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,7 @@ and returns the text. Just like ``(raw_)input``.
 
 .. code:: python
 
+    from __future__ import unicode_literals
     from prompt_toolkit import prompt
 
     text = prompt('Give me some input: ')


### PR DESCRIPTION
* Add `unicode_literals` import in "Getting Starded" code snippet
  
  I think it is important since I copied and pasted the code from the _"Getting Started"_ and it didn't work in python 2.7 (And I got just an `AssertionError`). I know there's a note about it in the _"Building prompts"_ section, but I already figured out the problem when I got there.

* Link to the stable version of the documentation

  There are some functions in the latest version of the docs that aren't available in the current version of the project (0.57). 