### PR TITLE
Allow ansi color name in Pygments style.

### DIFF
--- a/prompt_toolkit/styles/base.py
+++ b/prompt_toolkit/styles/base.py
@@ -18,8 +18,8 @@ __all__ = (
 #: Style attributes.
 Attrs = namedtuple('Attrs', 'color bgcolor bold underline italic blink reverse')
 """
-:param color: Hexadecimal string. E.g. '000000' or Ansi color name: e.g. 'magenta'
-:param bgcolor: Hexadecimal string. E.g. 'ffffff' or Ansi color name: e.g. 'magenta'
+:param color: Hexadecimal string. E.g. '000000' or Ansi color name: e.g. 'ansiblue'
+:param bgcolor: Hexadecimal string. E.g. 'ffffff' or Ansi color name: e.g. 'ansired'
 :param bold: Boolean
 :param underline: Boolean
 :param italic: Boolean
@@ -37,14 +37,14 @@ DEFAULT_ATTRS = Attrs(color=None, bgcolor=None, bold=False, underline=False,
 #: Usually, in that case, the terminal application allows to configure the RGB
 #: values for these names.
 ANSI_COLOR_NAMES = [
-    'black', 'white', 'default',
+    'ansiblack', 'ansiwhite', 'ansidefault',
 
     # Low intensity.
-    'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'gray',
+    'ansired', 'ansigreen', 'ansiyellow', 'ansiblue', 'ansifuchsia', 'ansiturquoise', 'ansilightgray',
 
     # High intensity. (Not supported everywhere.)
-    'dark-gray', 'bright-red', 'bright-green', 'bright-yellow', 'bright-blue',
-    'bright-magenta', 'bright-cyan',
+    'ansidarkgray', 'ansidarkred', 'ansidarkgreen', 'ansibrown', 'ansidarkblue',
+    'ansipurple', 'ansiteal',
 ]
 
 

--- a/prompt_toolkit/styles/from_dict.py
+++ b/prompt_toolkit/styles/from_dict.py
@@ -26,11 +26,13 @@ def _colorformat(text):
     """
     if text[0:1] == '#':
         col = text[1:]
-        if len(col) == 6:
+        if col in ANSI_COLOR_NAMES:
+            return col
+        elif len(col) == 6:
             return col
         elif len(col) == 3:
             return col[0]*2 + col[1]*2 + col[2]*2
-    elif text == '' or text in ANSI_COLOR_NAMES:
+    elif text == '':
         return text
 
     raise ValueError('Wrong color format %r' % text)

--- a/prompt_toolkit/terminal/vt100_output.py
+++ b/prompt_toolkit/terminal/vt100_output.py
@@ -24,78 +24,81 @@ __all__ = (
 
 
 FG_ANSI_COLORS = {
-    'black':   30,
-    'default': 39,
-    'white':   97,
+    'ansiblack':   30,
+    'ansidefault': 39,
+    'ansiwhite':   97,
 
     # Low intensity.
-    'red':     31,
-    'green':   32,
-    'yellow':  33,
-    'blue':    34,
-    'magenta': 35,
-    'cyan':    36,
-    'gray':    37,
+    'ansired':         31,
+    'ansigreen':       32,
+    'ansiyellow':      33,
+    'ansiblue':        34,
+    'ansifuchsia':     35,
+    'ansiturquoise':   36,
+    'ansilightgray':   37,
 
 
     # High intensity.
-    'dark-gray':      90,  # Bright black.
-    'bright-red':     91,
-    'bright-green':   92,
-    'bright-yellow':  93,
-    'bright-blue':    94,
-    'bright-magenta': 95,
-    'bright-cyan':    96,
+    'ansidarkgray':    90,  # Bright black.
+    'ansidarkred':     91,
+    'ansidarkgreen':   92,
+    'ansibrown':       93,
+    'ansidarkblue':    94,
+    'ansipurple':      95,
+    'ansiteal':        96,
 }
 
 BG_ANSI_COLORS = {
-    'black':   40,
-    'default': 49,
-    'white':   107,
+    'ansiblack':       40,
+    'ansidefault':     49,
+    'ansiwhite':       107,
 
     # Low intensity.
-    'red':     41,
-    'green':   42,
-    'yellow':  43,
-    'blue':    44,
-    'magenta': 45,
-    'cyan':    46,
-    'gray':    47,
+    'ansired':         41,
+    'ansigreen':       42,
+    'ansiyellow':      43,
+    'ansiblue':        44,
+    'ansifuchsia':     45,
+    'ansiturquoise':   46,
+    'ansilightgray':   47,
 
     # High intensity.
-    'dark-gray':      100,  # bright black.
-    'bright-red':     101,
-    'bright-green':   102,
-    'bright-yellow':  103,
-    'bright-blue':    104,
-    'bright-magenta': 105,
-    'bright-cyan':    106,
+    'ansidarkgray':    100,  # bright black.
+    'ansidarkred':     101,
+    'ansidarkgreen':   102,
+    'ansibrown':       103,
+    'ansidarkblue':    104,
+    'ansipurple':      105,
+    'ansiteal':        106,
 }
+
 
 ANSI_COLORS_TO_RGB = {
-    'black':   (0x00, 0x00, 0x00),
-    'default': (0x00, 0x00, 0x00),  # Don't use, 'default' doesn't really have a value.
-    'white':   (0xff, 0xff, 0xff),
+    'ansiblack':   (0x00, 0x00, 0x00),
+    'ansidefault': (0x00, 0x00, 0x00),  # Don't use, 'default' doesn't really have a value.
+    'ansiwhite':   (0xff, 0xff, 0xff),
 
-    # Low intensity.
-    'red':     (0xcd, 0x00, 0x00),
-    'green':   (0x00, 0xcd, 0x00),
-    'yellow':  (0xcd, 0xcd, 0x00),
-    'blue':    (0x00, 0x00, 0xcd),
-    'magenta': (0xcd, 0x00, 0xcd),
-    'cyan':    (0x00, 0xcd, 0xcd),
-    'gray':    (0xe5, 0xe5, 0xe5),
+    #Low intensity.
+    'ansired':         (0xcd, 0x00, 0x00),
+    'ansigreen':       (0x00, 0xcd, 0x00),
+    'ansiyellow':      (0xcd, 0xcd, 0x00),
+    'ansiblue':        (0x00, 0x00, 0xcd),
+    'ansifuchsia':     (0xcd, 0x00, 0xcd),
+    'ansiturquoise':   (0x00, 0xcd, 0xcd),
+    'ansilightgray':   (0xe5, 0xe5, 0xe5),
 
 
     # High intensity.
-    'dark-gray':      (0x7f, 0x7f, 0x7f),  # Bright black.
-    'bright-red':     (0xff, 0x00, 0x00),
-    'bright-green':   (0x00, 0xff, 0x00),
-    'bright-yellow':  (0xff, 0xff, 0x00),
-    'bright-blue':    (0x00, 0x00, 0xff),
-    'bright-magenta': (0xff, 0x00, 0xff),
-    'bright-cyan':    (0x00, 0xff, 0xff),
+    'ansidarkgray':    (0x7f, 0x7f, 0x7f),  # Bright black.
+    'ansidarkred':     (0xff, 0x00, 0x00),
+    'ansidarkgreen':   (0x00, 0xff, 0x00),
+    'ansibrown':       (0xff, 0xff, 0x00),
+    'ansidarkblue':    (0x00, 0x00, 0xff),
+    'ansipurple':      (0xff, 0x00, 0xff),
+    'ansiteal':        (0x00, 0xff, 0xff),
 }
+
+
 
 assert set(FG_ANSI_COLORS) == set(ANSI_COLOR_NAMES)
 assert set(BG_ANSI_COLORS) == set(ANSI_COLOR_NAMES)
@@ -219,7 +222,6 @@ class _EscapeCodeCache(dict):
 
     def __missing__(self, attrs):
         fgcolor, bgcolor, bold, underline, italic, blink, reverse = attrs
-
         parts = []
 
         if fgcolor:

--- a/prompt_toolkit/terminal/win32_output.py
+++ b/prompt_toolkit/terminal/win32_output.py
@@ -382,28 +382,28 @@ class BACKROUND_COLOR:
 def _create_ansi_color_dict(color_cls):
     " Create a table that maps the 16 named ansi colors to their Windows code. "
     return {
-        'black':   color_cls.BLACK,
-        'default': color_cls.BLACK,
-        'white':   color_cls.GRAY | color_cls.INTENSITY,
+        'ansiblack':   color_cls.BLACK,
+        'ansidefault': color_cls.BLACK,
+        'ansiwhite':   color_cls.GRAY | color_cls.INTENSITY,
 
         # Low intensity.
-        'red':     color_cls.RED,
-        'green':   color_cls.GREEN,
-        'yellow':  color_cls.YELLOW,
-        'blue':    color_cls.BLUE,
-        'magenta': color_cls.MAGENTA,
-        'cyan':    color_cls.CYAN,
-        'gray':    color_cls.GRAY,
+        'ansired':         color_cls.RED,
+        'ansigreen':       color_cls.GREEN,
+        'ansiyellow':      color_cls.YELLOW,
+        'ansiblue':        color_cls.BLUE,
+        'ansifuchsia':     color_cls.MAGENTA,
+        'ansiturquoise':   color_cls.CYAN,
+        'ansilightgray':   color_cls.GRAY,
 
 
         # High intensity.
-        'dark-gray':      color_cls.BLACK | color_cls.INTENSITY,
-        'bright-red':     color_cls.RED | color_cls.INTENSITY,
-        'bright-green':   color_cls.GREEN | color_cls.INTENSITY,
-        'bright-yellow':  color_cls.YELLOW | color_cls.INTENSITY,
-        'bright-blue':    color_cls.BLUE | color_cls.INTENSITY,
-        'bright-magenta': color_cls.MAGENTA | color_cls.INTENSITY,
-        'bright-cyan':    color_cls.CYAN | color_cls.INTENSITY,
+        'ansidarkgray':    color_cls.BLACK | color_cls.INTENSITY,
+        'ansidarkred':     color_cls.RED | color_cls.INTENSITY,
+        'ansidarkgreen':   color_cls.GREEN | color_cls.INTENSITY,
+        'ansibrown':       color_cls.YELLOW | color_cls.INTENSITY,
+        'ansidarkblue':    color_cls.BLUE | color_cls.INTENSITY,
+        'ansipurple':      color_cls.MAGENTA | color_cls.INTENSITY,
+        'ansiteal':        color_cls.CYAN | color_cls.INTENSITY,
     }
 
 FG_ANSI_COLORS = _create_ansi_color_dict(FOREGROUND_COLOR)

--- a/tests/style_tests.py
+++ b/tests/style_tests.py
@@ -24,18 +24,18 @@ class StyleFromDictTest(unittest.TestCase):
         style = style_from_dict({
             Token: '#ff0000',
             Token.A.B.C: 'bold',
-            Token.A.B.C.D: 'red',
+            Token.A.B.C.D: '#ansired',
             Token.A.B.C.D.E: 'noinherit blink'
         })
 
         expected = Attrs(color='ff0000', bgcolor=None, bold=True,
                          underline=False, italic=False, blink=False, reverse=False)
-        assert style.get_attrs_for_token(Token.A.B.C) == expected
+        self.assertEqual(style.get_attrs_for_token(Token.A.B.C), expected)
 
-        expected = Attrs(color='red', bgcolor=None, bold=True,
+        expected = Attrs(color='ansired', bgcolor=None, bold=True,
                          underline=False, italic=False, blink=False, reverse=False)
-        assert style.get_attrs_for_token(Token.A.B.C.D) == expected
+        self.assertEqual(style.get_attrs_for_token(Token.A.B.C.D), expected)
 
         expected = Attrs(color=None, bgcolor=None, bold=False,
                          underline=False, italic=False, blink=True, reverse=False)
-        assert style.get_attrs_for_token(Token.A.B.C.D.E) == expected
+        self.assertEqual(style.get_attrs_for_token(Token.A.B.C.D.E), expected)


### PR DESCRIPTION
Hey, 

I know that currently you can use vt100 to get GREN/BLUE ... etc, though if you create your own style that should work with pygments, it wont be accepted as these string won't be detected as correct colors.

Pygments recently added the ability to do that, except the names are slightly different, so this (once finished) should allow to have themes that works correctly with both Pygments 2.2+  and Prompt Toolkit **and** get the correct ansi escape sequences.