### PR TITLE
Changed dict check to Mapping

### DIFF
--- a/prompt_toolkit/styles/from_dict.py
+++ b/prompt_toolkit/styles/from_dict.py
@@ -6,6 +6,8 @@ This is very similar to the Pygments style dictionary, with some additions:
 - Support for ANSI color names. (These will map directly to the 16 terminal
   colors.)
 """
+from collections import Mapping
+
 from .base import Style, DEFAULT_ATTRS, ANSI_COLOR_NAMES
 from .defaults import DEFAULT_STYLE_EXTENSIONS
 from six.moves import range
@@ -36,7 +38,7 @@ def _colorformat(text):
 
 def style_from_dict(style_dict, include_defaults=True):
     """
-    Create a ``Style`` instance from a dictionary.
+    Create a ``Style`` instance from a dictionary or other mapping.
 
     The dictionary is equivalent to the ``Style.styles`` dictionary from
     pygments, with a few additions: it supports 'reverse' and 'blink'.
@@ -52,7 +54,7 @@ def style_from_dict(style_dict, include_defaults=True):
     :param include_defaults: Include the defaults (built-in) styling for
         selected text, etc...)
     """
-    assert isinstance(style_dict, dict)
+    assert isinstance(style_dict, Mapping)
 
     if include_defaults:
         s2 = {}


### PR DESCRIPTION
This is causing problems for some proposed xonsh changes.  Also there is no need to check against concrete types, usually. See https://github.com/scopatz/xonsh/pull/687#issuecomment-185802948

Note that we use ChainMap in our pygments Style class because of the need to keep different color namespaces separate.