### PR TITLE
Carry the weight in layout dimensions to allow stretching

### DIFF
--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -1001,7 +1001,7 @@ class Window(Container):
         else:
             max_ = dimension.max
 
-        return LayoutDimension(min=dimension.min, max=max_, preferred=preferred)
+        return LayoutDimension(min=dimension.min, max=max_, preferred=preferred, weight=dimension.weight)
 
     def _get_ui_content(self, cli, width, height):
         """


### PR DESCRIPTION
Otherwise things like the following don't work

```python
layout = VSplit([
    
    Window(D(weight=2), ...),

    Window(width=D.exact(1),   content=FillControl('|', token=Token.Line)),

    Window(D(weight=2), ...)),
])
```