### PR TITLE
Share code between HSplit, VSplit

### DIFF
--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -88,7 +88,25 @@ def _window_too_small():
 
 
 class XSplit(Container):
-    """A base class for HSplit and VSplit"""
+    """
+    Several layouts, one stacked next to the other.
+
+    Above/Under for ``HSplit``
+    Left/Right for ``VSplit``
+
+    :param children: List of child :class:`.Container` objects.
+    :param window_too_small: A :class:`.Container` object that is displayed if
+        there is not enough space for all the children. By default, this is a
+        "Window too small" message.
+    :param get_dimensions: (`None` or a callable that takes a
+        `CommandLineInterface` and returns a list of `LayoutDimension`
+        instances.) By default the dimensions are taken from the children and
+        divided by the available space. However, when `get_dimensions` is specified,
+        this is taken instead.
+    :param report_dimensions_callback: When rendering, this function is called
+        with the `CommandLineInterface` and the list of used dimensions. (As a
+        list of integers.)
+    """
 
     def __init__(self, children, window_too_small=None,
                  get_dimensions=None, report_dimensions_callback=None):
@@ -115,22 +133,6 @@ class XSplit(Container):
 
 
 class HSplit(XSplit):
-    """
-    Several layouts, one stacked above/under the other.
-
-    :param children: List of child :class:`.Container` objects.
-    :param window_too_small: A :class:`.Container` object that is displayed if
-        there is not enough space for all the children. By default, this is a
-        "Window too small" message.
-    :param get_dimensions: (`None` or a callable that takes a
-        `CommandLineInterface` and returns a list of `LayoutDimension`
-        instances.) By default the dimensions are taken from the children and
-        divided by the available space. However, when `get_dimensions` is specified,
-        this is taken instead.
-    :param report_dimensions_callback: When rendering, this function is called
-        with the `CommandLineInterface` and the list of used dimensions. (As a
-        list of integers.)
-    """
 
     def preferred_height(self, cli, width, max_available_height):
         dimensions = [c.preferred_height(cli, width, max_available_height) for c in self.children]
@@ -222,22 +224,6 @@ class HSplit(XSplit):
 
 
 class VSplit(XSplit):
-    """
-    Several layouts, one stacked left/right of the other.
-
-    :param children: List of child :class:`.Container` objects.
-    :param window_too_small: A :class:`.Container` object that is displayed if
-        there is not enough space for all the children. By default, this is a
-        "Window too small" message.
-    :param get_dimensions: (`None` or a callable that takes a
-        `CommandLineInterface` and returns a list of `LayoutDimension`
-        instances.) By default the dimensions are taken from the children and
-        divided by the available space. However, when `get_dimensions` is specified,
-        this is taken instead.
-    :param report_dimensions_callback: When rendering, this function is called
-        with the `CommandLineInterface` and the list of used dimensions. (As a
-        list of integers.)
-    """
 
     def preferred_width(self, cli, max_available_width):
         dimensions = [c.preferred_width(cli, max_available_width) for c in self.children]

--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -116,16 +116,16 @@ class HSplit(Container):
         self.get_dimensions = get_dimensions
         self.report_dimensions_callback = report_dimensions_callback
 
+    def preferred_height(self, cli, width, max_available_height):
+        dimensions = [c.preferred_height(cli, width, max_available_height) for c in self.children]
+        return sum_layout_dimensions(dimensions)
+
     def preferred_width(self, cli, max_available_width):
         if self.children:
             dimensions = [c.preferred_width(cli, max_available_width) for c in self.children]
             return max_layout_dimensions(dimensions)
         else:
             return LayoutDimension(0)
-
-    def preferred_height(self, cli, width, max_available_height):
-        dimensions = [c.preferred_height(cli, width, max_available_height) for c in self.children]
-        return sum_layout_dimensions(dimensions)
 
     def reset(self):
         for c in self.children:


### PR DESCRIPTION
H and VSplit share a lot of code,create an intermediary class. 


It seem that beyond the Swap width/height, the only difference is in `extended_height`, I suppose this is to allow things to overflow through the bottom of the screen. Would it make sens to introduce a (potentially useless)  `extended_width` and find a way to share more code ?
