### PR TITLE
Added line to match dark gray

### DIFF
--- a/prompt_toolkit/terminal/win32_output.py
+++ b/prompt_toolkit/terminal/win32_output.py
@@ -456,6 +456,7 @@ class ColorLookupTable(object):
             (0xff, 0x44, 0xff, FG.MAGENTA | FG.INTENSITY, BG.MAGENTA | BG.INTENSITY),
             (0xff, 0xff, 0x44, FG.YELLOW | FG.INTENSITY, BG.YELLOW | BG.INTENSITY),
 
+            (0x44, 0x44, 0x44, FG.BLACK | FG.INTENSITY, BG.BLACK | BG.INTENSITY),
             (0xff, 0xff, 0xff, FG.GRAY | FG.INTENSITY, BG.GRAY | BG.INTENSITY),
         ]
 


### PR DESCRIPTION
I think this line may be missing the color table. It is the only way I can get PT to match dark gray on windows. 