### PR TITLE
Safer list deletion for Registry.remove_binding()

### DIFF
--- a/prompt_toolkit/key_binding/registry.py
+++ b/prompt_toolkit/key_binding/registry.py
@@ -110,7 +110,9 @@ class Registry(object):
         """
         assert callable(function)
 
-        for b in self.key_bindings:
+        # We need to iterate over a copy of key_bindings to ensure correct
+        # deletion behavior.
+        for b in self.key_bindings[:]:
             if b.handler == function:
                 self.key_bindings.remove(b)
                 self._keys_to_bindings[b.keys].remove(b)


### PR DESCRIPTION
Iterating over a list while modifying it at the same time might lead to
unexpected results:

    >>> lst = list(range(10))
    >>> for x in lst:
    ...     lst.remove(x)
    >>> lst
    [1, 3, 5, 7, 9]

See Lennart Regebro's answer here: http://stackoverflow.com/a/1207427