### PR TITLE
Ignore common virtualenv locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ lib
 lib64
 __pycache__
 
+# Virtualenvs
+#  Common destinations (depending on developer) are env and venv, they can
+#  sometimes to preceded with a period (e.g. .venv) or followed by a number
+#  (e.g. venv3) or both (.venv3).
+*env*/
+
 # Installer logs
 pip-log.txt
 


### PR DESCRIPTION
This helps me a lot with playing with your libs (python-prompt-toolkit, pyvim, pymux) in development mode.

It depends on the project, but the common pattern virtualenv locations I see (when making them in the project directory) tend to be:

- ``env/``
- ``venv/``
- ``.venv/``
- ``.env/``
- ``env3/`` (these are esp. helpful since I often hop between a python 2 and python 3 env when testing)
- ``.env3/``
- ``.venv3/``
- ``venv3/``

I've been experimenting and found this regex ignores all of them. If there ever were a directory created with "env" anywhere in the name, this ignore would need to be revised.

What do you think?