### PR TITLE
If only one completion available apply it directly.

### DIFF
--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -693,6 +693,9 @@ class Buffer(object):
 
         # Set `complete_state`.
         if completions:
+            if len(completions) == 1:
+                self.apply_completion(completions[0])
+                return
             self.complete_state = CompletionState(
                 original_document=self.document,
                 current_completions=completions)


### PR DESCRIPTION
And do not display the completion menu.

reported in ipython/ipython#9540