### PR TITLE
Export `ViMode`

### DIFF
--- a/prompt_toolkit/filters/cli.py
+++ b/prompt_toolkit/filters/cli.py
@@ -23,6 +23,7 @@ __all__ = (
     'InEditingMode',
 
     # Vi modes.
+    'ViMode',
     'ViNavigationMode',
     'ViInsertMode',
     'ViReplaceMode',


### PR DESCRIPTION
`ViMode` should be exported, otherwise it is inconvenient to define keybinding for all vi modes.