### PR TITLE
history_search parameter seem to not exist.

### DIFF
--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -791,7 +791,6 @@ class Buffer(object):
         Move forwards through the history.
 
         :param count: Amount of items to move forward.
-        :param history_search: When True, filter history using ``self.history_search_text``.
         """
         self._set_history_search()
 


### PR DESCRIPTION
Though I'm curious how I can search backward through history without searching :-) 

(requested on IPython ML)