### PR TITLE
Don't select the first completion by default. (Undo the behaviour from 1.0.1)

### DIFF
--- a/prompt_toolkit/key_binding/bindings/completion.py
+++ b/prompt_toolkit/key_binding/bindings/completion.py
@@ -33,7 +33,7 @@ def generate_completions(event):
         second_tab()
     else:
         event.cli.start_completion(insert_common_part=True,
-                                   select_first=True)
+                                   select_first=False)
 
 
 def display_completions_like_readline(event):


### PR DESCRIPTION
See: https://github.com/ipython/ipython/issues/9629