### PR TITLE
Add cursor_position property to Completion

### DIFF
--- a/examples/autocompletion-with-cursor-position.py
+++ b/examples/autocompletion-with-cursor-position.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""
+Autocompletion example with cursor position not at the end of the completion.
+
+Press [Tab] to complete the current word.
+- The first Tab press fills in the common part of all completions
+    and shows all the completions. (In the menu)
+- Any following tab press cycles through all the possible completions.
+"""
+from __future__ import unicode_literals
+
+from prompt_toolkit.contrib.completers import WordCompleter
+from prompt_toolkit import prompt
+
+completions = [
+    ('upper_case()', 1),
+    ('lower_case()', 1),
+    ('list_add(list:=, element:=)', len(', element:=)')),
+    ('<html></html>', len('</html>'))
+]
+words, cursor_positions = zip(*completions)
+comp = WordCompleter(words, ignore_case=True, cursor_positions=cursor_positions)
+
+def main():
+    text = prompt('Input: ', completer=comp,
+                  complete_while_typing=False)
+    print('You said: %s' % text)
+
+
+if __name__ == '__main__':
+    main()

--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -137,7 +137,7 @@ class CompletionState(object):
                 before = original_text_before_cursor[:c.start_position]
 
             new_text = before + c.text + original_text_after_cursor
-            new_cursor_position = len(before) + len(c.text)
+            new_cursor_position = len(before) + len(c.text) - c.cursor_position
             return new_text, new_cursor_position
 
     @property

--- a/prompt_toolkit/completion.py
+++ b/prompt_toolkit/completion.py
@@ -24,13 +24,15 @@ class Completion(object):
         completion, e.g. the path or source where it's coming from.
     :param get_display_meta: Lazy `display_meta`. Retrieve meta information
         only when meta is displayed.
+    :param cursor_position: Cursor position after completion, from end
     """
     def __init__(self, text, start_position=0, display=None, display_meta=None,
-                 get_display_meta=None):
+                 get_display_meta=None, cursor_position=0):
         self.text = text
         self.start_position = start_position
         self._display_meta = display_meta
         self._get_display_meta = get_display_meta
+        self.cursor_position = cursor_position
 
         if display is None:
             self.display = text

--- a/prompt_toolkit/contrib/completers/base.py
+++ b/prompt_toolkit/contrib/completers/base.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from six import string_types
+import itertools
 from prompt_toolkit.completion import Completer, Completion
 
 __all__ = (
@@ -22,9 +23,10 @@ class WordCompleter(Completer):
         contain spaces. (Can not be used together with the WORD option.)
     :param match_middle: When True, match not only the start, but also in the
                          middle of the word.
+    :param cursor_positions optional iterable of cursor positions for the words
     """
     def __init__(self, words, ignore_case=False, meta_dict=None, WORD=False,
-                 sentence=False, match_middle=False):
+                 sentence=False, match_middle=False, cursor_positions=None):
         assert not (WORD and sentence)
 
         self.words = list(words)
@@ -33,6 +35,7 @@ class WordCompleter(Completer):
         self.WORD = WORD
         self.sentence = sentence
         self.match_middle = match_middle
+        self.cursor_positions = cursor_positions or itertools.repeat(0)
         assert all(isinstance(w, string_types) for w in self.words)
 
     def get_completions(self, document, complete_event):
@@ -55,7 +58,7 @@ class WordCompleter(Completer):
             else:
                 return word.startswith(word_before_cursor)
 
-        for a in self.words:
+        for a, p in zip(self.words, self.cursor_positions):
             if word_matches(a):
                 display_meta = self.meta_dict.get(a, '')
-                yield Completion(a, -len(word_before_cursor), display_meta=display_meta)
+                yield Completion(a, -len(word_before_cursor), display_meta=display_meta, cursor_position=p)

--- a/prompt_toolkit/interface.py
+++ b/prompt_toolkit/interface.py
@@ -804,6 +804,8 @@ class CommandLineInterface(object):
                             if common_part:
                                 # Insert + run completer again.
                                 buffer.insert_text(common_part)
+                                if len(completions) == 1:
+                                    buffer.cursor_position -= completions[0].cursor_position
                                 async_completer()
                                 set_completions = False
                             else:


### PR DESCRIPTION
`cursor_position` says how far from the end of the completion the cursor should be placed, so that we can have completions such as e.g. `<html[cursor]` -> `<html>[cursor]</html>`.