### PR TITLE
Implement Emacs Meta-. key binding (insert last word)

### DIFF
--- a/prompt_toolkit/interface.py
+++ b/prompt_toolkit/interface.py
@@ -32,7 +32,7 @@ from .key_binding.vi_state import ViState
 from .keys import Keys
 from .output import Output
 from .renderer import Renderer, print_tokens
-from .search_state import SearchState
+from .search_state import SearchState, SearchLastWordState
 from .utils import Event
 
 # Following import is required for backwards compatibility.
@@ -291,6 +291,7 @@ class CommandLineInterface(object):
         # Search new search state. (Does also remember what has to be
         # highlighted.)
         self.search_state = SearchState(ignore_case=Condition(lambda: self.is_ignoring_case))
+        self.search_last_word_state = SearchLastWordState()
 
         # Trigger reset event.
         self.on_reset.fire()

--- a/prompt_toolkit/key_binding/bindings/emacs.py
+++ b/prompt_toolkit/key_binding/bindings/emacs.py
@@ -300,7 +300,12 @@ def load_emacs_bindings(registry, filter=Always()):
         """
         Rotate through the last word (white-space delimited) of the previous lines in history.
         """
-        # TODO
+        buffer = event.current_buffer
+        search_state = event.cli.search_last_word_state
+        word_pos = (event.arg if event.arg_present else -1)
+        if not event.is_repeat:
+            search_state.reset()
+        buffer.insert_previous_nth_word(search_state, word_pos)
 
     @handle(Keys.Escape, '\\', filter=insert_mode)
     def _(event):

--- a/prompt_toolkit/key_binding/input_processor.py
+++ b/prompt_toolkit/key_binding/input_processor.py
@@ -312,6 +312,13 @@ class KeyPressEvent(object):
         """
         return self._arg or 1
 
+    @property
+    def arg_present(self):
+        """
+        True if repetition argument was explicitly provided.
+        """
+        return self._arg is not None
+
     def append_to_arg_count(self, data):
         """
         Add digit to the input argument.

--- a/prompt_toolkit/search_state.py
+++ b/prompt_toolkit/search_state.py
@@ -3,6 +3,7 @@ from .filters import to_simple_filter
 
 __all__ = (
     'SearchState',
+    'SearchLastWordState',
 )
 
 
@@ -34,3 +35,17 @@ class SearchState(object):
             direction = IncrementalSearchDirection.BACKWARD
 
         return SearchState(text=self.text, direction=direction, ignore_case=self.ignore_case)
+
+
+class SearchLastWordState(object):
+    def __init__(self, history_position=0, previous_word=''):
+        self.history_position = history_position
+        self.previous_word = previous_word
+
+    def reset(self):
+        self.history_position = 0
+        self.previous_word = ''
+
+    def __repr__(self):
+        return '%s(history_position=%r, previous_word=%r)' % (
+            self.__class__.__name__, self.history_position, self.previous_word)

--- a/tests/test_insert_last_word.py
+++ b/tests/test_insert_last_word.py
@@ -1,0 +1,61 @@
+from __future__ import unicode_literals
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.search_state import SearchLastWordState
+
+import pytest
+
+
+@pytest.fixture
+def _buffer():
+    buf = Buffer()
+    buf.insert_text('alpha beta gamma delta\n')
+    buf.reset(append_to_history=True)
+    buf.insert_text('one two three four\n')
+    buf.reset(append_to_history=True)
+    return buf
+
+
+@pytest.fixture
+def _search_state():
+    return SearchLastWordState()
+
+
+def test_empty_history(_buffer, _search_state):
+    buf = Buffer()
+    buf.insert_previous_nth_word(_search_state)
+    assert buf.document.current_line == ''
+
+
+def test_simple_search(_buffer, _search_state):
+    _buffer.insert_previous_nth_word(_search_state)
+    assert _buffer.document.current_line == 'four'
+
+
+def test_simple_search_with_quotes(_buffer, _search_state):
+    _buffer.insert_text("""one two "three 'x' four"\n""")
+    _buffer.reset(append_to_history=True)
+    _buffer.insert_previous_nth_word(_search_state)
+    assert _buffer.document.current_line == '''"three 'x' four"'''
+
+
+def test_simple_search_with_arg(_buffer, _search_state):
+    _buffer.insert_previous_nth_word(_search_state, word_pos=2)
+    assert _buffer.document.current_line == 'three'
+
+
+def test_simple_search_with_arg_out_of_bounds(_buffer, _search_state):
+    _buffer.insert_previous_nth_word(_search_state, word_pos=8)
+    assert _buffer.document.current_line == ''
+
+
+def test_repeated_search(_buffer, _search_state):
+    _buffer.insert_previous_nth_word(_search_state)
+    _buffer.insert_previous_nth_word(_search_state)
+    assert _buffer.document.current_line == 'delta'
+
+
+def test_repeated_search_with_wraparound(_buffer, _search_state):
+    _buffer.insert_previous_nth_word(_search_state)
+    _buffer.insert_previous_nth_word(_search_state)
+    _buffer.insert_previous_nth_word(_search_state)
+    assert _buffer.document.current_line == 'four'


### PR DESCRIPTION
Now when IPython uses prompt_toolkit, I miss readline's `Meta-.` keybinding a lot. Here's my attempt to implement it.
