### PR TITLE
Minor fix to save a redirect

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Python Prompt Toolkit
 and terminal applications in Python.
 
 Read the `documentation on readthedocs
-<http://python-prompt-toolkit.readthedocs.org/en/stable/>`_.
+<http://python-prompt-toolkit.readthedocs.io/en/stable/>`_.
 
 
 Ptpython


### PR DESCRIPTION
RTD links now use a .io domain, .org will redirect but .io is the newer recommendation.