### PR TITLE
Allow `words` to be a callable for WordCompleter

### DIFF
--- a/prompt_toolkit/contrib/completers/base.py
+++ b/prompt_toolkit/contrib/completers/base.py
@@ -12,7 +12,7 @@ class WordCompleter(Completer):
     """
     Simple autocompletion on a list of words.
 
-    :param words: List of words.
+    :param words: List of words, or a callable that produces a list of words.
     :param ignore_case: If True, case-insensitive completion.
     :param meta_dict: Optional dict mapping words to their meta-information.
     :param WORD: When True, use WORD characters.
@@ -27,13 +27,20 @@ class WordCompleter(Completer):
                  sentence=False, match_middle=False):
         assert not (WORD and sentence)
 
-        self.words = list(words)
+        if not callable(words):
+            assert all(isinstance(w, string_types) for w in words)
+            self.fetch_words = lambda: list(words)
+        else:
+            self.fetch_words = words
         self.ignore_case = ignore_case
         self.meta_dict = meta_dict or {}
         self.WORD = WORD
         self.sentence = sentence
         self.match_middle = match_middle
-        assert all(isinstance(w, string_types) for w in self.words)
+
+    @property
+    def words(self):
+        return self.fetch_words()
 
     def get_completions(self, document, complete_event):
         # Get word/text before cursor.

--- a/prompt_toolkit/contrib/completers/base.py
+++ b/prompt_toolkit/contrib/completers/base.py
@@ -12,7 +12,7 @@ class WordCompleter(Completer):
     """
     Simple autocompletion on a list of words.
 
-    :param words: List of words, or a callable that produces a list of words.
+    :param get_words: List of words, or a callable that produces a list of words.
     :param ignore_case: If True, case-insensitive completion.
     :param meta_dict: Optional dict mapping words to their meta-information.
     :param WORD: When True, use WORD characters.
@@ -23,15 +23,15 @@ class WordCompleter(Completer):
     :param match_middle: When True, match not only the start, but also in the
                          middle of the word.
     """
-    def __init__(self, words, ignore_case=False, meta_dict=None, WORD=False,
+    def __init__(self, get_words, ignore_case=False, meta_dict=None, WORD=False,
                  sentence=False, match_middle=False):
         assert not (WORD and sentence)
 
-        if not callable(words):
-            assert all(isinstance(w, string_types) for w in words)
-            self.fetch_words = lambda: list(words)
+        if not callable(get_words):
+            assert all(isinstance(w, string_types) for w in get_words)
+            self.fetch_words = lambda: list(get_words)
         else:
-            self.fetch_words = words
+            self.fetch_words = get_words
         self.ignore_case = ignore_case
         self.meta_dict = meta_dict or {}
         self.WORD = WORD

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -10,6 +10,7 @@ from six import text_type
 
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
+from prompt_toolkit.contrib.completers.base import WordCompleter
 from prompt_toolkit.contrib.completers.filesystem import PathCompleter
 
 
@@ -251,3 +252,38 @@ def test_pathcompleter_get_paths_constrains_path():
 
     # cleanup
     shutil.rmtree(test_dir)
+
+
+def test_word_completer_can_complete_on_static_word_list():
+    completer = WordCompleter(['abc', 'def'])
+    doc = Document('', 0)
+    event = CompleteEvent()
+    completions = completer.get_completions(doc, event)
+    result = [c.text for c in completions]
+    expected = ['abc', 'def']
+    assert expected == result
+
+
+def test_word_completer_can_complete_on_dynamic_word_list():
+    context = {'counter': 0}
+
+    def word_fetcher():
+        if context['counter'] == 0:
+            context['counter'] += 1
+            return ['alpha', 'beta']
+        else:
+            context['counter'] += 1
+            return ['aaa', 'bbb']
+
+    completer = WordCompleter(word_fetcher)
+    doc = Document('', 0)
+    event = CompleteEvent()
+    completions = completer.get_completions(doc, event)
+    result = [c.text for c in completions]
+    expected = ['alpha', 'beta']
+    assert expected == result
+
+    completions = completer.get_completions(doc, event)
+    result = [c.text for c in completions]
+    expected = ['aaa', 'bbb']
+    assert expected == result


### PR DESCRIPTION
so a hook can be called to fetch the word list under different context
