### PR TITLE
Failsafe for running from the python terminal

### DIFF
--- a/prompt_toolkit/terminal/win32_output.py
+++ b/prompt_toolkit/terminal/win32_output.py
@@ -47,16 +47,19 @@ class NoConsoleScreenBufferError(Exception):
     """
     def __init__(self):
         # Are we running in 'xterm' on Windows, like git-bash for instance?
-        xterm = 'xterm' in os.environ.get('TERM')
+        try:
+            xterm = 'xterm' in os.environ.get('TERM')
 
-        if xterm:
-            message = ('Found %s, while expecting a Windows console. '
-                       'Maybe try to run this program using "winpty" '
-                       'or run it in cmd.exe instead. Or otherwise, '
-                       'in case of Cygwin, use the Python executable '
-                       'that is compiled for Cygwin.' % os.environ['TERM'])
-        else:
-            message = 'No Windows console found. Are you running cmd.exe?'
+            if xterm:
+                message = ('Found %s, while expecting a Windows console. '
+                           'Maybe try to run this program using "winpty" '
+                           'or run it in cmd.exe instead. Or otherwise, '
+                           'in case of Cygwin, use the Python executable '
+                           'that is compiled for Cygwin.' % os.environ['TERM'])
+            else:
+                message = 'No Windows console found. Are you running cmd.exe?'
+        except TypeError:
+            message = 'No Windows console found. Are you running cmd.exe (You cannot run the application from idle)?'
         super(NoConsoleScreenBufferError, self).__init__(message)
 
 


### PR DESCRIPTION
If you try to run the application from idle and make a call to the interface, it gives a very cryptic error. This will at least make it easier to understand that you can't do that.
