### PR TITLE
FIX: Remove unnecessary (default) parameter

### DIFF
--- a/prompt_toolkit/terminal/vt100_output.py
+++ b/prompt_toolkit/terminal/vt100_output.py
@@ -314,7 +314,7 @@ def _get_size(fileno):
     buf = array.array(b'h' if six.PY2 else u'h', [0, 0, 0, 0])
 
     # Do TIOCGWINSZ (Get)
-    fcntl.ioctl(fileno, termios.TIOCGWINSZ, buf, True)
+    fcntl.ioctl(fileno, termios.TIOCGWINSZ, buf)
 
     # Return rows, cols
     return buf[0], buf[1]


### PR DESCRIPTION
Even if the [Zen of Python, item 2](https://www.python.org/dev/peps/pep-0020/#the-zen-of-python) says:
> Explicit is better than implicit.

And that the [python2 documentation](https://docs.python.org/2.7/library/fcntl.html#fcntl.ioctl) says:
> If `mutate_flag` is not supplied, then from Python 2.5 it defaults to true, which is a change from versions 2.3 and 2.4. Supply the argument explicitly if *version portability* is a priority.

And that the [python2 documentation](https://docs.python.org/3.4/library/fcntl.html#fcntl.ioctl) says:
> If `mutate_flag` is true (the default), ...

The truth is that the two implementations of `fcntl.ioctl(fileno, termios.TIOCGWINSZ, buf, True)` and `cntl.ioctl(fileno, termios.TIOCGWINSZ, buf)` differ greatly, as can be seen [here](https://hg.python.org/cpython/file/2.7/Modules/fcntlmodule.c#l122) and [here](https://hg.python.org/cpython/file/2.7/Modules/fcntlmodule.c#l178). They differ so much that they are not equivalent on all systems, and that *version portability* is harming *direct portability* (i.e. portability across different systems running the same version); as can be seen from [this bug report](http://bugs.alpinelinux.org/issues/5981).

While this might be related to the aforementioned system (Alpine Linux), or one of its components (grsec/PaX or musl-libc), it is also possible for it to be a python bug.

In any case, this PR solves the problem (segmentation fault) that the [first implementation](https://hg.python.org/cpython/file/2.7/Modules/fcntlmodule.c#l122) seems to cause.

Since future-proof portability is IMHO more important than legacy-proof portability (AKA *version portability*), I opened this PR.

HTH.