### PR TITLE
Don't call select() on Windows in InputHookContext

### DIFF
--- a/prompt_toolkit/eventloop/inputhook.py
+++ b/prompt_toolkit/eventloop/inputhook.py
@@ -79,7 +79,9 @@ class InputHookContext(object):
             # monkey patched and won't be cooperative, so that would block all
             # other select() calls otherwise.
             # See: http://www.gevent.org/gevent.os.html
-            select_fds([self._r], timeout=None)
+            if os.name != 'nt':
+                # Windows select() can't be used on fds
+                select_fds([self._r], timeout=None)
 
             os.read(self._r, 1024)
         except OSError:


### PR DESCRIPTION
Windows select() can't be used on fds, so this will always fail.

I've no idea if the gevent problem this was meant to prevent can occur on Windows.

Closes gh-367

See also ipython/ipython#9836