### PR TITLE
SentenceValidator: Remove set comprehension to support python 2.6

### DIFF
--- a/prompt_toolkit/contrib/validators/base.py
+++ b/prompt_toolkit/contrib/validators/base.py
@@ -21,7 +21,7 @@ class SentenceValidator(Validator):
         self.move_cursor_to_end = move_cursor_to_end
 
         if ignore_case:
-            self.sentences = {s.lower() for s in self.sentences}
+            self.sentences = set([s.lower() for s in self.sentences])
 
     def validate(self, document):
         if document.text not in self.sentences:


### PR DESCRIPTION
Set comprehensions aren't available in python 2.6, so I've converted it to a list comprehension cast as a set.