### PR TITLE
Avoid extra vertical scrolling on windows if the cursor is already on screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ nosetests.xml
 
 # Generated documentation
 docs/_build
+
+# pycharm metadata
+.idea

--- a/prompt_toolkit/terminal/win32_output.py
+++ b/prompt_toolkit/terminal/win32_output.py
@@ -305,7 +305,11 @@ class Win32Output(Output):
 
         # Scroll vertical
         win_height = sr.Bottom - sr.Top
-        result.Bottom = max(win_height, cursor_pos.Y)
+        if 0 < sr.Bottom - cursor_pos.Y < win_height - 1:
+            # no vertical scroll if cursor already on the screen
+            result.Bottom = sr.Bottom
+        else:
+            result.Bottom = max(win_height, cursor_pos.Y)
         result.Top = result.Bottom - win_height
 
         # Scroll API


### PR DESCRIPTION
```win32_output.scroll_buffer_to_prompt()``` tries to scroll the cursor onto the screen with a preference to place the cursor at the bottom if the buffer is larger than the view-port.  This does not take in to account that the cursor may already be in the view-port.  If the cursor is in the view-port, it is moved to the bottom, and then very shortly there after moved up 8 lines to account for the reserved area for the menu.  Using https://github.com/click-contrib/click-repl this causes the screen to flicker anytime the screen is scrolled.

This PR leaves the vertical scroll unchanged if the cursor is already in the view-port.