### PR TITLE
ensure get('TERM') returns a string

### DIFF
--- a/prompt_toolkit/terminal/win32_output.py
+++ b/prompt_toolkit/terminal/win32_output.py
@@ -47,7 +47,7 @@ class NoConsoleScreenBufferError(Exception):
     """
     def __init__(self):
         # Are we running in 'xterm' on Windows, like git-bash for instance?
-        xterm = 'xterm' in os.environ.get('TERM')
+        xterm = 'xterm' in os.environ.get('TERM', '')
 
         if xterm:
             message = ('Found %s, while expecting a Windows console. '


### PR DESCRIPTION
otherwise `'xterm' in None` will raise TypeError when TERM is not in env

cf ipython/ipython#9921