### PR TITLE
Fix ansicolors codes for windows terminal.

### DIFF
--- a/prompt_toolkit/terminal/vt100_output.py
+++ b/prompt_toolkit/terminal/vt100_output.py
@@ -25,77 +25,76 @@ __all__ = (
 
 
 FG_ANSI_COLORS = {
-    'ansiblack':   30,
     'ansidefault': 39,
+    'ansiblack':   30,
+    'ansidarkgray': 37,
+    'ansilightgray':90,
     'ansiwhite':   97,
 
     # Low intensity.
-    'ansired':         31,
-    'ansigreen':       32,
-    'ansiyellow':      33,
-    'ansiblue':        34,
-    'ansifuchsia':     35,
-    'ansiturquoise':   36,
-    'ansilightgray':   37,
-
+    'ansidarkred':     31,
+    'ansidarkgreen':   32,
+    'ansibrown':       33,
+    'ansidarkblue':    34,
+    'ansipurple':      35,
+    'ansiteal':        36,
 
     # High intensity.
-    'ansidarkgray':    90,  # Bright black.
-    'ansidarkred':     91,
-    'ansidarkgreen':   92,
-    'ansibrown':       93,
-    'ansidarkblue':    94,
-    'ansipurple':      95,
-    'ansiteal':        96,
+    'ansired':         91,
+    'ansigreen':       92,
+    'ansiyellow':      93,
+    'ansiblue':        94,
+    'ansifuchsia':     95,
+    'ansiturquoise':   96,
 }
 
 BG_ANSI_COLORS = {
-    'ansiblack':       40,
     'ansidefault':     49,
+    'ansiblack':       40,
+    'ansidarkgray':    47,
     'ansiwhite':       107,
+    'ansilightgray':   100,
 
     # Low intensity.
-    'ansired':         41,
-    'ansigreen':       42,
-    'ansiyellow':      43,
-    'ansiblue':        44,
-    'ansifuchsia':     45,
-    'ansiturquoise':   46,
-    'ansilightgray':   47,
+    'ansidarkred':     41,
+    'ansidarkgreen':   42,
+    'ansibrown':       43,
+    'ansidarkblue':    44,
+    'ansipurple':      45,
+    'ansiteal':        46,
 
     # High intensity.
-    'ansidarkgray':    100,  # bright black.
-    'ansidarkred':     101,
-    'ansidarkgreen':   102,
-    'ansibrown':       103,
-    'ansidarkblue':    104,
-    'ansipurple':      105,
-    'ansiteal':        106,
+    'ansired':         101,
+    'ansigreen':       102,
+    'ansiyellow':      103,
+    'ansiblue':        104,
+    'ansifuchsia':     105,
+    'ansiturquoise':   106,
 }
 
 
 ANSI_COLORS_TO_RGB = {
-    'ansiblack':   (0x00, 0x00, 0x00),
-    'ansidefault': (0x00, 0x00, 0x00),  # Don't use, 'default' doesn't really have a value.
-    'ansiwhite':   (0xff, 0xff, 0xff),
+    'ansidefault':   (0x00, 0x00, 0x00),  # Don't use, 'default' doesn't really have a value.
+    'ansiblack':     (0x00, 0x00, 0x00),
+    'ansidarkgray':  (0x7f, 0x7f, 0x7f), 
+    'ansiwhite':     (0xff, 0xff, 0xff),
+    'ansilightgray': (0xe5, 0xe5, 0xe5),
 
     # Low intensity.
-    'ansired':         (0xcd, 0x00, 0x00),
-    'ansigreen':       (0x00, 0xcd, 0x00),
-    'ansiyellow':      (0xcd, 0xcd, 0x00),
-    'ansiblue':        (0x00, 0x00, 0xcd),
-    'ansifuchsia':     (0xcd, 0x00, 0xcd),
-    'ansiturquoise':   (0x00, 0xcd, 0xcd),
-    'ansilightgray':   (0xe5, 0xe5, 0xe5),
+    'ansidarkred':     (0xcd, 0x00, 0x00),
+    'ansidarkgreen':   (0x00, 0xcd, 0x00),
+    'ansibrown':       (0xcd, 0xcd, 0x00),
+    'ansidarkblue':    (0x00, 0x00, 0xcd),
+    'ansipurple':      (0xcd, 0x00, 0xcd),
+    'ansiteal':        (0x00, 0xcd, 0xcd),
 
     # High intensity.
-    'ansidarkgray':    (0x7f, 0x7f, 0x7f),  # Bright black.
-    'ansidarkred':     (0xff, 0x00, 0x00),
-    'ansidarkgreen':   (0x00, 0xff, 0x00),
-    'ansibrown':       (0xff, 0xff, 0x00),
-    'ansidarkblue':    (0x00, 0x00, 0xff),
-    'ansipurple':      (0xff, 0x00, 0xff),
-    'ansiteal':        (0x00, 0xff, 0xff),
+    'ansired':         (0xff, 0x00, 0x00),
+    'ansigreen':       (0x00, 0xff, 0x00),
+    'ansiyellow':      (0xff, 0xff, 0x00),
+    'ansiblue':        (0x00, 0x00, 0xff),
+    'ansifuchsia':     (0xff, 0x00, 0xff),
+    'ansiturquoise':   (0x00, 0xff, 0xff),
 }
 
 

--- a/prompt_toolkit/terminal/win32_output.py
+++ b/prompt_toolkit/terminal/win32_output.py
@@ -407,28 +407,27 @@ class BACKROUND_COLOR:
 def _create_ansi_color_dict(color_cls):
     " Create a table that maps the 16 named ansi colors to their Windows code. "
     return {
-        'ansiblack':   color_cls.BLACK,
-        'ansidefault': color_cls.BLACK,
-        'ansiwhite':   color_cls.GRAY | color_cls.INTENSITY,
-
+        'ansidefault':   color_cls.BLACK,
+        'ansiblack':     color_cls.BLACK,
+        'ansidarkgray':  color_cls.BLACK | color_cls.INTENSITY,
+        'ansilightgray': color_cls.GRAY,
+        'ansiwhite':     color_cls.GRAY | color_cls.INTENSITY,
+        
         # Low intensity.
-        'ansired':         color_cls.RED,
-        'ansigreen':       color_cls.GREEN,
-        'ansiyellow':      color_cls.YELLOW,
-        'ansiblue':        color_cls.BLUE,
-        'ansifuchsia':     color_cls.MAGENTA,
-        'ansiturquoise':   color_cls.CYAN,
-        'ansilightgray':   color_cls.GRAY,
-
+        'ansidarkred':     color_cls.RED,
+        'ansidarkgreen':   color_cls.GREEN,
+        'ansibrown':       color_cls.YELLOW,
+        'ansidarkblue':    color_cls.BLUE,
+        'ansipurple':      color_cls.MAGENTA,
+        'ansiteal':        color_cls.CYAN,
 
         # High intensity.
-        'ansidarkgray':    color_cls.BLACK | color_cls.INTENSITY,
-        'ansidarkred':     color_cls.RED | color_cls.INTENSITY,
-        'ansidarkgreen':   color_cls.GREEN | color_cls.INTENSITY,
-        'ansibrown':       color_cls.YELLOW | color_cls.INTENSITY,
-        'ansidarkblue':    color_cls.BLUE | color_cls.INTENSITY,
-        'ansipurple':      color_cls.MAGENTA | color_cls.INTENSITY,
-        'ansiteal':        color_cls.CYAN | color_cls.INTENSITY,
+        'ansired':        color_cls.RED | color_cls.INTENSITY,
+        'ansigreen':      color_cls.GREEN | color_cls.INTENSITY,
+        'ansiyellow':     color_cls.YELLOW | color_cls.INTENSITY,
+        'ansiblue':       color_cls.BLUE | color_cls.INTENSITY,
+        'ansifuchsia':    color_cls.MAGENTA | color_cls.INTENSITY,
+        'ansiturquoise':  color_cls.CYAN | color_cls.INTENSITY,
     }
 
 FG_ANSI_COLORS = _create_ansi_color_dict(FOREGROUND_COLOR)


### PR DESCRIPTION
The high and low intensity color codes (ansi-color names) seem to be swapped by prompt-toolkit on windows. 

This PR fixes this. Now teal is the dark color, and ansiturquoise the light color. The same goes for the rest of the color names. 
