### PR TITLE
Import prompt_async shortcut in __init__, too

### DIFF
--- a/prompt_toolkit/__init__.py
+++ b/prompt_toolkit/__init__.py
@@ -15,7 +15,7 @@ Probably, to get started, you meight also want to have a look at
 """
 from .interface import CommandLineInterface
 from .application import AbortAction, Application
-from .shortcuts import prompt
+from .shortcuts import prompt, prompt_async
 
 
 # Don't forget to update in `docs/conf.py`!


### PR DESCRIPTION
So the example in https://python-prompt-toolkit.readthedocs.io/en/stable/pages/building_prompts.html#prompt-in-an-asyncio-application would work. (Also, it's (probably) more convenient? :^)
