### PR TITLE
Implementation of a search-and-replace feature

### DIFF
--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -261,6 +261,8 @@ class Buffer(object):
         # using multiple cursors.)
         self.multiple_cursor_positions = []
 
+        self.substitute_selection_ranges = []
+
         # When doing consecutive up/down movements, prefer to stay at this column.
         self.preferred_column = None
 
@@ -1132,6 +1134,8 @@ class Buffer(object):
             working_index, cursor_position = search_result
             self.working_index = working_index
             self.cursor_position = cursor_position
+
+        return search_result is not None
 
     def exit_selection(self):
         self.selection_state = None

--- a/prompt_toolkit/key_binding/bindings/vi.py
+++ b/prompt_toolkit/key_binding/bindings/vi.py
@@ -1744,6 +1744,30 @@ def load_vi_search_bindings(registry, get_search_state=None,
     selection_mode = ViSelectionMode()
     handle = create_handle_decorator(registry, filter & ViMode())
 
+    @handle('s', filter=selection_mode)
+    def _(event):
+        """
+        Search text (in order to replace it in the selection).
+        """
+        buff = event.current_buffer
+
+        # Store selection ranges.
+        ranges = []
+
+        for from_to in buff.document.selection_ranges():
+            ranges.append(list(from_to))
+
+        buff.substitute_selection_ranges = ranges
+
+        event.current_buffer.exit_selection()
+        event.current_buffer.cursor_position = ranges[0][0]
+        # Set the ViState.
+        get_search_state(event.cli).direction = IncrementalSearchDirection.FORWARD
+        event.cli.vi_state.input_mode = InputMode.INSERT
+
+        # Focus search buffer.
+        event.cli.push_focus(search_buffer_name)
+
     @handle('/', filter=navigation_mode|selection_mode)
     @handle(Keys.ControlS, filter=~has_focus)
     def _(event):
@@ -1833,6 +1857,66 @@ def load_vi_search_bindings(registry, get_search_state=None,
         event.cli.pop_focus()
         event.cli.buffers[search_buffer_name].reset()
 
+    @handle('/', filter=has_focus)
+    def _(event):
+        """
+        Replace the searched text.
+        """
+        ranges = event.cli.buffers.previous(event.cli).substitute_selection_ranges
+        if len(ranges) > 0:
+            positions = []
+
+            text_length = len(event.cli.buffers[search_buffer_name].text)
+
+            # Apply the search:
+            input_buffer = event.cli.buffers.previous(event.cli)
+            search_buffer = event.cli.buffers[search_buffer_name]
+
+            # Update search state.
+            if search_buffer.text:
+                get_search_state(event.cli).text = search_buffer.text
+
+            # Apply search.
+            input_buffer.apply_search(get_search_state(event.cli))
+
+            # Add query to history of search line.
+            search_buffer.append_to_history()
+            search_buffer.reset()
+
+            # Focus previous document again.
+            event.cli.vi_state.input_mode = InputMode.NAVIGATION
+            event.cli.pop_focus()
+
+            done0 = False
+            i0 = 0
+            while (not done0):
+                from_, to = ranges[i0]
+                done1 = False
+                while (not done1):
+                    if from_ <= event.current_buffer.cursor_position <= to - text_length + 1:
+                        positions.append(event.current_buffer.cursor_position)
+                        event.current_buffer.delete(count=text_length)
+                        for i1 in range(i0, len(ranges)):
+                            if i1 > i0:
+                                ranges[i1][0] -= text_length
+                            ranges[i1][1] -= text_length
+                        to -= text_length
+                        if not event.current_buffer.apply_search(
+                            get_search_state(event.cli), include_current_position=True,
+                            count=1):
+                            done1 = True
+                    else:
+                        done1 = True
+                i0 += 1
+                if i0 == len(ranges):
+                    done0 = True
+
+            event.cli.buffers[search_buffer_name].reset()
+            ranges = []
+            if len(positions) > 0:
+                event.current_buffer.multiple_cursor_positions = positions
+                event.current_buffer.cursor_position = positions[0]
+                event.cli.vi_state.input_mode = InputMode.INSERT_MULTIPLE
 
 def load_extra_vi_page_navigation_bindings(registry, filter=None):
     """


### PR DESCRIPTION
Hi @jonathanslenders,

Here is a search-and-replace feature that is a first step towards the Vi substitute command. It doesn't follow the `:s/foo/bar/g` syntax, instead you need to hit `s` in selection mode, enter the searched text, hit `/`, enter the replacing text, and finally hit `Esc`. The matching text inside the selection will be replaced.
I couldn't implement the Vi syntax because I don't know how `:s` can be catched by prompt-toolkit instead of pyvim (I used pyvim to test this feature), or if it should be catched in pyvim. If you have any idea, please let me know.

David.