### PR TITLE
Fix IndexError in operate-and-get-next command

### DIFF
--- a/prompt_toolkit/key_binding/bindings/named_commands.py
+++ b/prompt_toolkit/key_binding/bindings/named_commands.py
@@ -561,7 +561,8 @@ def operate_and_get_next(event):
 
     # Set the new index at the start of the next run.
     def set_working_index():
-        buff.working_index = new_index
+        if new_index < len(buff._working_lines):
+            buff.working_index = new_index
 
     event.cli.pre_run_callables.append(set_working_index)
 


### PR DESCRIPTION
Ctrl+O shortcut is broken when `buffer.working_index` is pointing at the last working line.