### PR TITLE
Added missing explicit loops for Futures in asyncio_posix eventloop.

### DIFF
--- a/prompt_toolkit/eventloop/asyncio_posix.py
+++ b/prompt_toolkit/eventloop/asyncio_posix.py
@@ -22,7 +22,7 @@ class PosixAsyncioEventLoop(EventLoop):
         self.loop = loop or asyncio.get_event_loop()
         self.closed = False
 
-        self._stopped_f = asyncio.Future()
+        self._stopped_f = asyncio.Future(loop=self.loop)
 
     @asyncio.coroutine
     def run_as_coroutine(self, stdin, callbacks):
@@ -41,7 +41,7 @@ class PosixAsyncioEventLoop(EventLoop):
 
         try:
             # Create a new Future every time.
-            self._stopped_f = asyncio.Future()
+            self._stopped_f = asyncio.Future(loop=self.loop)
 
             # Handle input timouts
             def timeout_handler():


### PR DESCRIPTION
I have encountered this during testing my app using prompt-toolkit with pytest-asyncio and an explicit eventloop (https://github.com/pytest-dev/pytest-asyncio#pytestmarkasyncioforbid_global_loopfalse).