### PR TITLE
Handle arguments in the $EDITOR or $VISUAL env variable

### DIFF
--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -1316,7 +1316,7 @@ class Buffer(object):
         for e in editors:
             if e:
                 try:
-                    returncode = subprocess.call([e, filename])
+                    returncode = subprocess.call(e.split(' ') + [filename])
                     return returncode == 0
 
                 except OSError:


### PR DESCRIPTION
On OSX, users will typically use `subl -w` to use sublime tet on
blocking mode, though this will be passed ass it to subprocess.call
leading to the `subl -w` command not found.

See ipython/ipython#9929

this should fix that. It would affect users with actual space on the
path of their editor executable, but I'm unsure how to handle both case.
It seem to me like passing flags would be the most common use case.

Workaround is to tell users to create an shim executable which pass the
options.