### PR TITLE
Fix raw input on SmartOS

### DIFF
--- a/prompt_toolkit/terminal/vt100_input.py
+++ b/prompt_toolkit/terminal/vt100_input.py
@@ -459,6 +459,8 @@ class raw_mode(object):
         else:
             newattr[tty.LFLAG] = self._patch_lflag(newattr[tty.LFLAG])
             newattr[tty.IFLAG] = self._patch_iflag(newattr[tty.IFLAG])
+            newattr[tty.CC][termios.VMIN] = 1
+
             termios.tcsetattr(self.fileno, termios.TCSANOW, newattr)
 
             # Put the terminal in cursor mode. (Instead of application mode.)


### PR DESCRIPTION
I found that on SmartOS (Illumos/Solaris derivative OS), IPython would not echo my input until I had typed 4 characters. I tracked it down to how prompt-toolkit was setting the terminal attributes: it was not setting VMIN (min characters to read). On SmartOS this defaults to 4. On Linux this defaults to 1. Setting it to 1 fixed my problem.

It may be worth checking this behaves correctly on Mac OS X - there is a comment that says tty.setraw fails for this OS, and tty.setraw also sets VMIN = 1. Can it be confirmed exactly how tty.setraw fails for Mac OS X? It may be worth just using tty.setraw instead.