### PR TITLE
Don't save undo state with CPRResponse

### DIFF
--- a/prompt_toolkit/key_binding/bindings/basic.py
+++ b/prompt_toolkit/key_binding/bindings/basic.py
@@ -196,7 +196,7 @@ def load_basic_bindings():
         """
         event.current_buffer.insert_text(event.data)
 
-    @handle(Keys.CPRResponse)
+    @handle(Keys.CPRResponse, save_before=lambda e: False)
     def _(event):
         """
         Handle incoming Cursor-Position-Request response.


### PR DESCRIPTION
This gets called all the time, and ends up clearing the redo state instantly
after an undo.

Fixes #419.