### PR TITLE
handle the case of non-terminal input and output

### DIFF
--- a/prompt_toolkit/eventloop/posix_utils.py
+++ b/prompt_toolkit/eventloop/posix_utils.py
@@ -49,11 +49,18 @@ class PosixStdinReader(object):
         #: True when there is nothing anymore to read.
         self.closed = False
 
-    def read(self, count=1024):
+    def read(self, count=1):
             # By default we choose a rather small chunk size, because reading
             # big amounts of input at once, causes the event loop to process
             # all these key bindings also at once without going back to the
             # loop. This will make the application feel unresponsive.
+            #
+            # Update: if count > 1 and you read from a file (e.g. a script) 
+            # you are going to skip newlines and mix two successive commands;
+            # usually a prompt input is not a huge stream, so reading it 1-by-1
+            # is not too bad, but perhaps there's a better way to fix the above
+            # problem -FS 
+    
         """
         Read the input and return it as a string.
 


### PR DESCRIPTION
In this commit I handled a use case that is apparently not covered by your code (as discussed in #411). 

Roughly speaking: the same prompt can be configured to read from a file/stream or from a terminal; in the first case the output goes to a file/stream (tipically the stdout) without caring of the cursor position (there is no need of sending CPRs). In the second case (prompt reading from a terminal), the Vt100_Output class does its job just fine.

I did two main things:
- slighly changed the renderer to consume one char at the time, so if reading from a file a don't mix the input of two different lines
- added a StandardOutput class that does most of the job that Vt100_Output did, but it ignores the CPRs

At the moment StandardOutput is only used for linux systems, but I don't have a windows system to test with. We can consider making StandardOutput a common class for both the linux terminal output (Vt100_Output) and the windows one (I don't know what class handles it).