### PR TITLE
Make a copy of key_sequences in _call_handler

### DIFF
--- a/prompt_toolkit/key_binding/input_processor.py
+++ b/prompt_toolkit/key_binding/input_processor.py
@@ -227,6 +227,7 @@ class InputProcessor(object):
             cli.invalidate()
 
     def _call_handler(self, handler, key_sequence=None):
+        key_sequence = key_sequence[:]
         was_recording = self.record_macro
         arg = self.arg
         self.arg = None


### PR DESCRIPTION
The _process method mutates the list of key sequences (calls del on it), which
ends up breaking the previous_key_sequences. Previously, it was just a list of
the current key sequence, but now it is correctly a list of the previously
handled key sequence.

Fixes #468.