### PR TITLE
Remove a duplicate checking of row range.

### DIFF
--- a/prompt_toolkit/document.py
+++ b/prompt_toolkit/document.py
@@ -632,7 +632,7 @@ class Document(object):
         column = self.cursor_position_col if preferred_column is None else preferred_column
 
         return self.translate_row_col_to_index(
-            max(0, self.cursor_position_row - count), column) - self.cursor_position
+            self.cursor_position_row - count, column) - self.cursor_position
 
     def get_cursor_down_position(self, count=1, preferred_column=None):
         """


### PR DESCRIPTION
This is not a serious issue.

I noticed `get_cursor_up_position` method has duplicate checking of the row range because `translate_row_col_to_index` method is:
https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/prompt_toolkit/document.py#L308-L310