### PR TITLE
2.0: do not pass `arg` to _get_arg_text

### DIFF
--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -700,8 +700,8 @@ class Prompt(object):
         return to_formatted_text(
             prompt_continuation, style='class:prompt-continuation')
 
-    def _get_arg_text(self, app):
-        arg = app.key_processor.arg
+    def _get_arg_text(self):
+        arg = self.app.key_processor.arg
         if arg == '-':
             arg = '-1'
 


### PR DESCRIPTION
I got this error when hitting a number in vi mode.

```
  File "/Users/Randy/Dropbox/R/Rice/rice/deps/prompt_toolkit/formatted_text.py", line 58, in to_forma
tted_text                                                                                            
    return to_formatted_text(value(), style=style)                                                   
                                                                                                     
Exception _get_arg_text() missing 1 required positional argument: 'app' 
```