### PR TITLE
2.0: fix search toolbar text for multiline mode

### DIFF
--- a/prompt_toolkit/layout/widgets/toolbars.py
+++ b/prompt_toolkit/layout/widgets/toolbars.py
@@ -173,7 +173,7 @@ class SearchToolbar(object):
     """
     :param vi_mode: Display '/' and '?' instead of I-search.
     """
-    def __init__(self, search_buffer, vi_mode=False):
+    def __init__(self, search_buffer, get_search_state=None, vi_mode=False):
         assert isinstance(search_buffer, Buffer)
 
         def get_before_input():
@@ -187,6 +187,7 @@ class SearchToolbar(object):
 
         self.control = BufferControl(
             buffer=search_buffer,
+            get_search_state=get_search_state,
             input_processor=BeforeInput(get_before_input),
             lexer=SimpleLexer(
                 style='class:search-toolbar.text'))

--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -363,7 +363,8 @@ class Prompt(object):
             filter=~is_done & renderer_height_is_known &
                     Condition(lambda: self.bottom_toolbar is not None))
 
-        search_toolbar = SearchToolbar(search_buffer)
+        search_toolbar = SearchToolbar(
+            search_buffer, get_search_state=lambda: default_buffer_control.get_search_state())
         search_buffer_control = BufferControl(
             buffer=search_buffer,
             input_processor=merge_processors([


### PR DESCRIPTION
fix #553 


The cause is the `app.layout.current_control` being the search control instead of the default control. So `app.current_search_state` fails to get the correct state. This fix allows the search control to access the search state of the default buffer.