### PR TITLE
examples: fix broken import statements

### DIFF
--- a/examples/full-screen/pager.py
+++ b/examples/full-screen/pager.py
@@ -10,7 +10,7 @@ from prompt_toolkit.layout.containers import HSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import LayoutDimension as D
 from prompt_toolkit.layout.layout import Layout
-from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.styles import Style
 from prompt_toolkit.widgets import TextArea, SearchToolbar
 

--- a/examples/full-screen/text-editor.py
+++ b/examples/full-screen/text-editor.py
@@ -14,7 +14,7 @@ from prompt_toolkit.layout.containers import Float, HSplit, VSplit, Window, Alig
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import D
 from prompt_toolkit.layout.layout import Layout
-from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.styles import Style
 from prompt_toolkit.widgets import Dialog, Label, Button, TextArea, SearchToolbar, MenuContainer, MenuItem

--- a/examples/full-screen/yes-no-dialog.py
+++ b/examples/full-screen/yes-no-dialog.py
@@ -11,7 +11,7 @@ from prompt_toolkit.key_binding.bindings.focus import focus_next, focus_previous
 from prompt_toolkit.layout.containers import VSplit, HSplit, Float
 from prompt_toolkit.layout.dimension import D
 from prompt_toolkit.layout.layout import Layout
-from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.styles import Style, merge_styles
 from prompt_toolkit.widgets import TextArea, Label, Frame, Box, Checkbox, Dialog, Button, RadioList, MenuContainer, MenuItem, ProgressBar

--- a/examples/prompts/custom-lexer.py
+++ b/examples/prompts/custom-lexer.py
@@ -3,7 +3,7 @@
 An example of a custom lexer that prints the input text in random colors.
 """
 from __future__ import unicode_literals
-from prompt_toolkit.layout.lexers import Lexer
+from prompt_toolkit.lexers import Lexer
 from prompt_toolkit.styles.named_colors import NAMED_COLORS
 from prompt_toolkit.shortcuts import prompt
 

--- a/examples/prompts/html-input.py
+++ b/examples/prompts/html-input.py
@@ -6,7 +6,7 @@ Simple example of a syntax-highlighted HTML input line.
 from __future__ import unicode_literals
 from pygments.lexers import HtmlLexer
 from prompt_toolkit import prompt
-from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.lexers import PygmentsLexer
 
 
 def main():

--- a/examples/prompts/inputhook.py
+++ b/examples/prompts/inputhook.py
@@ -14,7 +14,7 @@ There are two ways to know when input is ready. One way is to poll
 from __future__ import unicode_literals
 
 from prompt_toolkit.eventloop.defaults import create_event_loop
-from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.shortcuts import Prompt
 from pygments.lexers import PythonLexer

--- a/examples/prompts/regular-language.py
+++ b/examples/prompts/regular-language.py
@@ -19,7 +19,7 @@ from prompt_toolkit import prompt
 from prompt_toolkit.contrib.regular_languages.compiler import compile
 from prompt_toolkit.contrib.regular_languages.completion import GrammarCompleter
 from prompt_toolkit.contrib.regular_languages.lexer import GrammarLexer
-from prompt_toolkit.layout.lexers import SimpleLexer
+from prompt_toolkit.lexers import SimpleLexer
 from prompt_toolkit.styles import Style
 
 import math

--- a/examples/tutorial/sqlite-cli.py
+++ b/examples/tutorial/sqlite-cli.py
@@ -7,7 +7,7 @@ from prompt_toolkit import prompt
 from prompt_toolkit.contrib.completers import WordCompleter
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.styles import Style
-from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.lexers import PygmentsLexer
 
 from pygments.lexers import SqlLexer
 


### PR DESCRIPTION
Some examples no longer work since the path to the lexers module has changed.