### PR TITLE
Fixed typo in docs in an example color name

### DIFF
--- a/docs/pages/printing_text.rst
+++ b/docs/pages/printing_text.rst
@@ -102,7 +102,7 @@ Both foreground and background colors can also be defined using the `fg` and
 .. code:: python
 
     # Colors from the ANSI palette.
-    print_formatted_text(HTML('<span fg="#ff0044" bg="seegreen">Red on green</span>'))
+    print_formatted_text(HTML('<span fg="#ff0044" bg="seagreen">Red on green</span>'))
 
 
 Underneath, all tags are mapped to classes from the style sheet. So, if you use


### PR DESCRIPTION
The ["printing text" page](http://python-prompt-toolkit.readthedocs.io/en/stable/pages/printing_text.html#printing-text) of the docs has a typo on the given example color:
`print_formatted_text(HTML('<span fg="#ff0044" bg="seegreen">Red on green</span>'))`