### PR TITLE
Added Slacker to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,7 @@ Shells:
 - `robotframework-debuglibrary <https://github.com/xyb/robotframework-debuglibrary>`_: A debug library and REPL for RobotFramework.
 - `ptrepl <https://github.com/imomaliev/ptrepl>`_: Run any command as REPL
 - `clipwdmgr <https://github.com/samisalkosuo/clipasswordmgr>`_: Command Line Password Manager.
+- `slacker <https://github.com/netromdk/slacker>`_: Easy access to the Slack API and admin of workspaces via REPL.
 
 Full screen applications:
 


### PR DESCRIPTION
Thanks for a great toolkit!

We're using it for [Slacker](https://github.com/netromdk/slacker) and would like to have it added to your list of projects using your toolkit.

Thanks.