### PR TITLE
reset completion state as a fallback

### DIFF
--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -1508,6 +1508,10 @@ class Buffer(object):
                         # exactly one match.)
                         if len(completions) == 1:
                             self.go_to_completion(0)
+                else:
+                    if not completions:
+                        # reset completion state anyway
+                        self.complete_state = None
 
             else:
                 # If the last operation was an insert, (not a delete), restart


### PR DESCRIPTION
I figured out that in some situations, the `tab` key for requesting completions is not working because previous completion state is not clear. This PR clears the state if none of the conditions were matched.