### PR TITLE
Add dictionary search in RadioList

### DIFF
--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -31,6 +31,7 @@ from prompt_toolkit.layout.margins import ScrollbarMargin, NumberedMargin
 from prompt_toolkit.layout.processors import PasswordProcessor, ConditionalProcessor, BeforeInput
 from prompt_toolkit.mouse_events import MouseEventType
 from prompt_toolkit.utils import get_cwidth
+from prompt_toolkit.keys import Keys
 
 from .toolbars import SearchToolbar
 
@@ -507,6 +508,14 @@ class RadioList(object):
         @kb.add(' ')
         def _(event):
             self.current_value = self.values[self._selected_index][0]
+
+        @kb.add(Keys.Any)
+        def _(event):
+            # We first check values after the selected value, then all values.
+            for value in self.values[self._selected_index + 1:] + self.values:
+                if value[1].startswith(event.data):
+                    self._selected_index = self.values.index(value)
+                    return
 
         # Control and window.
         self.control = FormattedTextControl(


### PR DESCRIPTION
### This PR is a rebase of https://github.com/jonathanslenders/python-prompt-toolkit/pull/620

Hello,

This is my first contribution to prompt_toolkit. I've implemented it with what I knew.

This PR:
- adds a key binder so that when one type a letter while having a `RadioList` opened, it automatically switches to the next entry starting with that letter. This behavior is the same than in explorer for instance.

Demo code:

```python
from __future__ import unicode_literals
from prompt_toolkit.formatted_text import HTML
from prompt_toolkit.shortcuts.dialogs import radiolist_dialog
result = radiolist_dialog(
    values=[
        ('red', 'Red'),
        ('green', 'Green'),
        ('blue', 'Blue'),
        ('blue2', 'Blue2'),
        ('blue3', 'Blue'),
        ('bluec', 'blue. hi, im case sensitive'),
        ('orange', 'Orange'),
        ('orange', 'Orange2'),
        ('blue4', 'Blue again'),
    ],
    title='Radiolist dialog example',
    text='Please select a color:'
)
```

Then type, for instance, "B" (note the cap letter), several times

 If you have any good advices on how to do this in a better way, please tell me