### PR TITLE
Fix mismatched tags in HTML example.

### DIFF
--- a/docs/pages/printing_text.rst
+++ b/docs/pages/printing_text.rst
@@ -85,7 +85,7 @@ italic and underline: ``<b>``, ``<i>`` and ``<u>``.
     from prompt_toolkit import print_formatted_text, HTML
 
     print_formatted_text(HTML('<b>This is bold</b>'))
-    print_formatted_text(HTML('<i>This is italic</b>'))
+    print_formatted_text(HTML('<i>This is italic</i>'))
     print_formatted_text(HTML('<u>This is underlined</u>'))
 
 Further, it's possible to use tags for foreground colors:


### PR DESCRIPTION
<i> was closed using </b>