### PR TITLE
Added `default` parameter to RadioList and radiolist_dialog

### DIFF
--- a/prompt_toolkit/shortcuts/dialogs.py
+++ b/prompt_toolkit/shortcuts/dialogs.py
@@ -111,14 +111,14 @@ def message_dialog(title='', text='', ok_text='Ok', style=None, async_=False):
 
 
 def radiolist_dialog(title='', text='', ok_text='Ok', cancel_text='Cancel',
-                     values=None, style=None, async_=False):
+                     values=None, style=None, async_=False, default=0):
     """
     Display a simple message box and wait until the user presses enter.
     """
     def ok_handler():
         get_app().exit(result=radio_list.current_value)
 
-    radio_list = RadioList(values)
+    radio_list = RadioList(values, default)
 
     dialog = Dialog(
         title=title,

--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -497,16 +497,19 @@ class RadioList(object):
     List of radio buttons. Only one can be checked at the same time.
 
     :param values: List of (value, label) tuples.
+    :param default: Default index to select, defaults to 0
     """
-    def __init__(self, values):
+    def __init__(self, values, default=0):
         assert isinstance(values, list)
         assert len(values) > 0
         assert all(isinstance(i, tuple) and len(i) == 2
                    for i in values)
+        assert 0 <= default < len(values)
 
         self.values = values
-        self.current_value = values[0][0]
-        self._selected_index = 0
+
+        self.current_value = values[default][0]
+        self._selected_index = default
 
         # Key bindings.
         kb = KeyBindings()


### PR DESCRIPTION
Default index allows for pre-selecting an entry in a list,
useful for dialogs with many values.

I've found this useful if the dialog is updating something that was already selected previously.