### PR TITLE
Making more pygments lexers imports explicit

### DIFF
--- a/docs/pages/asking_for_input.rst
+++ b/docs/pages/asking_for_input.rst
@@ -90,7 +90,7 @@ base class.
 
 .. code:: python
 
-    from pygments.lexers import HtmlLexer
+    from pygments.lexers.html import HtmlLexer
     from prompt_toolkit.shortcuts import prompt
     from prompt_toolkit.lexers import PygmentsLexer
 
@@ -105,7 +105,7 @@ you can do the following:
 
 .. code:: python
 
-    from pygments.lexers import HtmlLexer
+    from pygments.lexers.html import HtmlLexer
     from pygments.styles import get_style_by_name
     from prompt_toolkit.shortcuts import prompt
     from prompt_toolkit.lexers import PygmentsLexer
@@ -134,7 +134,7 @@ function:
 
 .. code:: python
 
-    from pygments.lexers import HtmlLexer
+    from pygments.lexers.html import HtmlLexer
     from prompt_toolkit.shortcuts import prompt
     from prompt_toolkit.styles import Style
     from prompt_toolkit.lexers import PygmentsLexer
@@ -178,7 +178,7 @@ Creating a custom style could be done like this:
     from prompt_toolkit.lexers import PygmentsLexer
 
     from pygments.styles.tango import TangoStyle
-    from pygments.lexers import HtmlLexer
+    from pygments.lexers.html import HtmlLexer
 
     our_style = merge_styles([
         style_from_pygments_cls(TangoStyle),

--- a/docs/pages/printing_text.rst
+++ b/docs/pages/printing_text.rst
@@ -230,7 +230,7 @@ Similarly, it is also possible to print the output of a Pygments lexer:
 
     import pygments
     from pygments.token import Token
-    from pygments.lexers import PythonLexer
+    from pygments.lexers.python import PythonLexer
 
     from prompt_toolkit.formatted_text import PygmentsTokens
     from prompt_toolkit import print_formatted_text

--- a/docs/pages/tutorials/repl.rst
+++ b/docs/pages/tutorials/repl.rst
@@ -95,7 +95,7 @@ wrapped into a :class:`~prompt_toolkit.lexers.PygmentsLexer`.
     from __future__ import unicode_literals
     from prompt_toolkit import PromptSession
     from prompt_toolkit.lexers import PygmentsLexer
-    from pygments.lexers import SqlLexer
+    from pygments.lexers.sql import SqlLexer
 
     def main():
         session = PromptSession(lexer=PygmentsLexer(SqlLexer)
@@ -138,7 +138,7 @@ Like the lexer, this ``sql_completer`` instance can be passed to either the
     from prompt_toolkit import PromptSession
     from prompt_toolkit.completion import WordCompleter
     from prompt_toolkit.lexers import PygmentsLexer
-    from pygments.lexers import SqlLexer
+    from pygments.lexers.sql import SqlLexer
 
     sql_completer = WordCompleter([
         'abort', 'action', 'add', 'after', 'all', 'alter', 'analyze', 'and',
@@ -200,7 +200,7 @@ function.
     from prompt_toolkit.completion import WordCompleter
     from prompt_toolkit.lexers import PygmentsLexer
     from prompt_toolkit.styles import Style
-    from pygments.lexers import SqlLexer
+    from pygments.lexers.sql import SqlLexer
 
     sql_completer = WordCompleter([
         'abort', 'action', 'add', 'after', 'all', 'alter', 'analyze', 'and',
@@ -274,7 +274,7 @@ gives a good idea of how to get started.
     from prompt_toolkit.completion import WordCompleter
     from prompt_toolkit.lexers import PygmentsLexer
     from prompt_toolkit.styles import Style
-    from pygments.lexers import SqlLexer
+    from pygments.lexers.sql import SqlLexer
 
     sql_completer = WordCompleter([
         'abort', 'action', 'add', 'after', 'all', 'alter', 'analyze', 'and',

--- a/examples/full-screen/pager.py
+++ b/examples/full-screen/pager.py
@@ -14,7 +14,7 @@ from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.styles import Style
 from prompt_toolkit.widgets import TextArea, SearchToolbar
 
-from pygments.lexers import PythonLexer
+from pygments.lexers.python import PythonLexer
 
 
 # Create one text buffer for the main content.

--- a/examples/print-text/pygments-tokens.py
+++ b/examples/print-text/pygments-tokens.py
@@ -6,7 +6,7 @@ or an output of a Pygments lexer.
 from __future__ import unicode_literals
 import pygments
 from pygments.token import Token
-from pygments.lexers import PythonLexer
+from pygments.lexers.python import PythonLexer
 
 from prompt_toolkit import print_formatted_text
 from prompt_toolkit.formatted_text import PygmentsTokens

--- a/examples/prompts/html-input.py
+++ b/examples/prompts/html-input.py
@@ -4,7 +4,7 @@ Simple example of a syntax-highlighted HTML input line.
 (This requires Pygments to be installed.)
 """
 from __future__ import unicode_literals
-from pygments.lexers import HtmlLexer
+from pygments.lexers.html import HtmlLexer
 from prompt_toolkit import prompt
 from prompt_toolkit.lexers import PygmentsLexer
 

--- a/examples/prompts/inputhook.py
+++ b/examples/prompts/inputhook.py
@@ -17,7 +17,7 @@ from prompt_toolkit.eventloop.defaults import create_event_loop
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.shortcuts import PromptSession
-from pygments.lexers import PythonLexer
+from pygments.lexers.python import PythonLexer
 
 import gtk
 import gobject

--- a/examples/tutorial/sqlite-cli.py
+++ b/examples/tutorial/sqlite-cli.py
@@ -7,7 +7,7 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.styles import Style
-from pygments.lexers import SqlLexer
+from pygments.lexers.sql import SqlLexer
 
 sql_completer = WordCompleter([
     'abort', 'action', 'add', 'after', 'all', 'alter', 'analyze', 'and',

--- a/prompt_toolkit/lexers/pygments.py
+++ b/prompt_toolkit/lexers/pygments.py
@@ -131,7 +131,7 @@ class PygmentsLexer(Lexer):
 
     Example::
 
-        from pygments.lexers import HtmlLexer
+        from pygments.lexers.html import HtmlLexer
         lexer = PygmentsLexer(HtmlLexer)
 
     Note: Don't forget to also load a Pygments compatible style. E.g.::


### PR DESCRIPTION
I think I have found all places in code and doc where importing of pygments lexers needed to be more explicit to avoid making IDE's like PyCharm complain.