### PR TITLE
Don't start a timeout thread if already waiting

### DIFF
--- a/prompt_toolkit/renderer.py
+++ b/prompt_toolkit/renderer.py
@@ -388,11 +388,12 @@ class Renderer(object):
                 return
             else:
                 # Asks for a cursor position report (CPR).
+                start_timer = len(self._waiting_for_cpr_futures) == 0
                 self._waiting_for_cpr_futures.append(Future())
                 self.output.ask_for_cpr()
 
                 # If we don't know whether CPR is supported, test using timer.
-                if self.cpr_support == CPR_Support.UNKNOWN:
+                if self.cpr_support == CPR_Support.UNKNOWN and start_timer:
                     def timer():
                         time.sleep(self.CPR_TIMEOUT)
 


### PR DESCRIPTION
Only start 1 timeout thread ever to set state to NOT_SUPPORTED.  Avoids using extra resources unnecessarily & avoids cpr_not_supported_callback being called multiple times if it isn't supported (since there's no lock being held when self.cpr_support is being checked/modified).

Fixes #687