### PR TITLE
Fix line wrap mouse scroll

### DIFF
--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -2014,10 +2014,17 @@ class Window(Container):
         info = self.render_info
 
         if self.vertical_scroll < info.content_height - info.window_height:
+            should_scroll = True
+        elif self.allow_scroll_beyond_bottom() and self.vertical_scroll < info.content_height:
+            should_scroll = True
+        else:
+            should_scroll = False
+
+        if should_scroll:
+            self.vertical_scroll += 1
             if info.cursor_position.y <= info.configured_scroll_offsets.top:
                 self.content.move_cursor_down()
 
-            self.vertical_scroll += 1
 
     def _scroll_up(self):
         " Scroll window up. "

--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -2015,10 +2015,20 @@ class Window(Container):
 
         if self.vertical_scroll < info.content_height - info.window_height:
             should_scroll = True
-        elif self.allow_scroll_beyond_bottom() and self.vertical_scroll < info.content_height:
+        elif self.allow_scroll_beyond_bottom() and self.vertical_scroll < info.content_height - 1:
             should_scroll = True
-        else:
+        elif self.vertical_scroll == info.content_height - 1:
             should_scroll = False
+        else:
+            # Cycle through remaining lines for a line with more than one line
+            height = 0
+            for line in range(self.vertical_scroll, info.content_height):
+                height += info.get_height_for_line(line)
+                if height > info.window_height:
+                    should_scroll = True
+                    break
+            else:
+                should_scroll = False
 
         if should_scroll:
             self.vertical_scroll += 1

--- a/tests/test_mouse_scroll.py
+++ b/tests/test_mouse_scroll.py
@@ -1,0 +1,126 @@
+from __future__ import unicode_literals
+
+from prompt_toolkit.layout.screen import Screen, WritePosition
+from prompt_toolkit.layout.mouse_handlers import MouseHandlers
+from prompt_toolkit.layout.containers import Window
+from prompt_toolkit.layout.controls import BufferControl
+from prompt_toolkit.buffer import Buffer
+
+import pytest
+
+width = 10
+height = 4
+
+@pytest.fixture
+def dim():
+    return { "base_width":10,
+             "win_width":10,
+             "win_height":4,
+             "buf_height": 40 }
+
+
+@pytest.fixture
+def content(dim):
+    buff = Buffer()
+    line = "*" * dim["base_width"]
+    for i in range(dim["buf_height"]):
+        buff.insert_text(line)
+        buff.newline()
+    buff.cursor_up(dim["buf_height"] + 1)
+    control = BufferControl(buffer=buff)
+    return control
+
+
+@pytest.fixture
+def window(content, dim):
+    win = Window(content=content)
+    win.reset()
+    update(win, dim)
+    assert win.vertical_scroll == 0
+    assert win.render_info.ui_content.cursor_position.y == 0
+    return win
+
+@pytest.fixture
+def window_allow_scroll(content, dim):
+    win = Window(content=content, allow_scroll_beyond_bottom=True)
+    win.reset()
+    update(win, dim)
+    assert win.vertical_scroll == 0
+    assert win.render_info.ui_content.cursor_position.y == 0
+    return win
+
+def scroll(window, dim, direction, count, delay_update=False):
+    for i in range(count):
+        if direction == "up":
+            window._scroll_up()
+        elif direction == "down":
+            window._scroll_down()
+        else:
+            # Just make sure we don't do this on accident
+            assert False
+        if not delay_update:
+            update(window, dim)
+
+    if delay_update:
+        update(window, dim)
+
+
+def update(window, dim):
+    window.write_to_screen(Screen(),
+                           MouseHandlers(),
+                           WritePosition(xpos=0,
+                                         ypos=0,
+                                         width=dim["win_width"],
+                                         height=dim["win_height"]),
+                           parent_style='',
+                           erase_bg=False,
+                           z_index=None)
+
+
+def check_scroll(window, vertical_scroll, cursor_y):
+    assert window.vertical_scroll == vertical_scroll
+    assert window.render_info.ui_content.cursor_position.y == cursor_y
+
+
+def test_scroll_down(window, dim):
+    scroll(window, dim, "down", 1)
+    check_scroll(window, 1, 1)
+
+    scroll(window, dim, "down", 2)
+    check_scroll(window, 3, 3)
+
+    scroll(window, dim, "down", 4)
+    check_scroll(window, 7, 7)
+
+def test_scroll_up(window, dim):
+    test_scroll_down(window, dim)
+    scroll(window, dim, "up", 1)
+    check_scroll(window, 6, 7)
+    scroll(window, dim, "up", 2)
+    check_scroll(window, 4, 7)
+    scroll(window, dim, "up", 1)
+    check_scroll(window, 3, 6)
+
+def test_multiple_scroll_before_render(window, dim):
+    scroll(window, dim, "down", 10, delay_update=True)
+    check_scroll(window, 10, 10)
+
+    scroll(window, dim, "up", 1, delay_update=True)
+    scroll(window, dim, "down", 1, delay_update=True)
+    check_scroll(window, 10, 10)
+
+def test_scroll_to_end(window, dim):
+    # Regardless of how much we scroll, we should stop with the
+    # last line of the window the last line of the buffer
+    last_line = dim["buf_height"] - dim["win_height"] + 1
+
+    scroll(window, dim, "down", dim["buf_height"]*2)
+    check_scroll(window, last_line, last_line)
+
+def test_scroll_beyond_end(window_allow_scroll, dim):
+
+    last_line = dim["buf_height"] - dim["win_height"] + 1
+    scroll(window_allow_scroll, dim, "down", last_line)
+    check_scroll(window_allow_scroll, last_line, last_line)
+    scroll(window_allow_scroll, dim, "down", 1)
+    check_scroll(window_allow_scroll, last_line + 1, last_line + 1)

--- a/tests/test_mouse_scroll.py
+++ b/tests/test_mouse_scroll.py
@@ -34,6 +34,15 @@ def content(dim):
 
 
 @pytest.fixture
+def empty_window(dim):
+    win = Window(content=BufferControl(buffer=Buffer()))
+    win.reset()
+    update(win, dim)
+    assert win.vertical_scroll == 0
+    assert win.render_info.ui_content.cursor_position.y == 0
+    return win
+
+@pytest.fixture
 def window(content, dim):
     win = Window(content=content)
     win.reset()
@@ -84,6 +93,12 @@ def check_scroll(window, vertical_scroll, cursor_y):
     assert window.render_info.ui_content.cursor_position.y == cursor_y
 
 
+def test_empty_window(empty_window, dim):
+    scroll(empty_window, dim, "down", 1)
+    check_scroll(empty_window, 0, 0)
+    scroll(empty_window, dim, "up", 1)
+    check_scroll(empty_window, 0, 0)
+
 def test_scroll_down(window, dim):
     scroll(window, dim, "down", 1)
     check_scroll(window, 1, 1)
@@ -102,6 +117,8 @@ def test_scroll_up(window, dim):
     check_scroll(window, 4, 7)
     scroll(window, dim, "up", 1)
     check_scroll(window, 3, 6)
+    scroll(window, dim, "up", dim["buf_height"] * 2)
+    check_scroll(window, 0, dim["win_height"] - 1)
 
 def test_multiple_scroll_before_render(window, dim):
     scroll(window, dim, "down", 10, delay_update=True)
@@ -116,7 +133,7 @@ def test_scroll_to_end(window, dim):
     # last line of the window the last line of the buffer
     last_line = dim["buf_height"] - dim["win_height"]
 
-    scroll(window, dim, "down", dim["buf_height"]*2)
+    scroll(window, dim, "down", dim["buf_height"] * 2)
     check_scroll(window, last_line, last_line)
 
 def test_scroll_past_end_before_render(window, dim):
@@ -136,3 +153,4 @@ def test_scroll_beyond_end(window_allow_scroll, dim):
     # Max out scrolling
     scroll(window_allow_scroll, dim, "down", dim["buf_height"])
     check_scroll(window_allow_scroll, dim["buf_height"] - 1, dim["buf_height"] - 1)
+

--- a/tests/test_mouse_scroll.py
+++ b/tests/test_mouse_scroll.py
@@ -23,9 +23,11 @@ def dim():
 def content(dim):
     buff = Buffer()
     line = "*" * dim["base_width"]
-    for i in range(dim["buf_height"]):
+    for i in range(dim["buf_height"] - 1):
         buff.insert_text(line)
         buff.newline()
+    buff.insert_text(line)
+
     buff.cursor_up(dim["buf_height"] + 1)
     control = BufferControl(buffer=buff)
     return control
@@ -112,15 +114,25 @@ def test_multiple_scroll_before_render(window, dim):
 def test_scroll_to_end(window, dim):
     # Regardless of how much we scroll, we should stop with the
     # last line of the window the last line of the buffer
-    last_line = dim["buf_height"] - dim["win_height"] + 1
+    last_line = dim["buf_height"] - dim["win_height"]
 
     scroll(window, dim, "down", dim["buf_height"]*2)
     check_scroll(window, last_line, last_line)
 
-def test_scroll_beyond_end(window_allow_scroll, dim):
+def test_scroll_past_end_before_render(window, dim):
+    # Regardless of how much we scroll, we should stop with the
+    # last line of the window the last line of the buffer
+    last_line = dim["buf_height"] - dim["win_height"]
 
-    last_line = dim["buf_height"] - dim["win_height"] + 1
+    scroll(window, dim, "down", dim["buf_height"]*2, delay_update=True)
+    check_scroll(window, last_line, last_line)
+
+def test_scroll_beyond_end(window_allow_scroll, dim):
+    last_line = dim["buf_height"] - dim["win_height"]
     scroll(window_allow_scroll, dim, "down", last_line)
     check_scroll(window_allow_scroll, last_line, last_line)
     scroll(window_allow_scroll, dim, "down", 1)
     check_scroll(window_allow_scroll, last_line + 1, last_line + 1)
+    # Max out scrolling
+    scroll(window_allow_scroll, dim, "down", dim["buf_height"])
+    check_scroll(window_allow_scroll, dim["buf_height"] - 1, dim["buf_height"] - 1)


### PR DESCRIPTION
For issue #168  
This fixes some of the mouse scrolling issues with Window. And adds some unit tests to check them.

* Can't scroll to end with `wrap_lines`
* Can't scroll past end with `allow_scroll_beyond_bottom`

Still needs work to get scrolling up to work. It currently stops scrolling up when the amount of lines needed to add a line from the top would force the cursor off screen after moving up 1 line. Or if the cursor is not on the last line of the window but on the last line of the visible lines.