### PR TITLE
progress_bar.formatters.Bar needs to compute length of start, end, and sym_b

### DIFF
--- a/prompt_toolkit/shortcuts/progress_bar/formatters.py
+++ b/prompt_toolkit/shortcuts/progress_bar/formatters.py
@@ -129,8 +129,10 @@ class Bar(Formatter):
         self.sym_c = sym_c
         self.unknown = unknown
 
+        self._reserved_width = len(start) + len(sym_b) + len(end)
+
     def format(self, progress_bar, progress, width):
-        width -= 3  # Subtract left '|', bar_b and right '|'
+        width -= self._reserved_width  # Subtract left, bar_b and right
 
         if progress.total:
             pb_a = int(progress.percentage * width / 100)


### PR DESCRIPTION
No assumptions are made about how long the start and end patterns should be. As a consequence we need to then also format the resulting Bar based on how long the start and end patterns are, not hardcode their widths to 1.