### PR TITLE
Added get_line_prefix attribute to Window.

### DIFF
--- a/examples/full-screen/simple-demos/line-prefixes.py
+++ b/examples/full-screen/simple-demos/line-prefixes.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""
+An example of a BufferControl in a full screen layout that offers auto
+completion.
+
+Important is to make sure that there is a `CompletionsMenu` in the layout,
+otherwise the completions won't be visible.
+"""
+from __future__ import unicode_literals
+from prompt_toolkit.application import Application
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.completion import WordCompleter
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout.containers import HSplit, Window, FloatContainer, Float
+from prompt_toolkit.layout.controls import FormattedTextControl, BufferControl
+from prompt_toolkit.layout.layout import Layout
+from prompt_toolkit.layout.menus import CompletionsMenu
+
+
+LIPSUM = """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Maecenas
+quis interdum enim. Nam viverra, mauris et blandit malesuada, ante est bibendum
+mauris, ac dignissim dui tellus quis ligula. Aenean condimentum leo at
+dignissim placerat. In vel dictum ex, vulputate accumsan mi. Donec ut quam
+placerat massa tempor elementum. Sed tristique mauris ac suscipit euismod. Ut
+tempus vehicula augue non venenatis. Mauris aliquam velit turpis, nec congue
+risus aliquam sit amet. Pellentesque blandit scelerisque felis, faucibus
+consequat ante. Curabitur tempor tortor a imperdiet tincidunt. Nam sed justo
+sit amet odio bibendum congue. Quisque varius ligula nec ligula gravida, sed
+convallis augue faucibus. Nunc ornare pharetra bibendum. Praesent blandit ex
+quis sodales maximus."""
+
+
+def get_line_prefix(lineno, wrap_count):
+    if wrap_count == 0:
+        return HTML('[%s] <style bg="orange" fg="black">--&gt;</style> ') % lineno
+
+    text = str(lineno) + '-' + '*' * (lineno // 2) + ': '
+    return HTML('[%s.%s] <style bg="ansigreen" fg="ansiblack">%s</style>') % (
+        lineno, wrap_count, text)
+
+
+# Global wrap lines flag.
+wrap_lines = True
+
+
+# The layout
+buff = Buffer(complete_while_typing=True)
+buff.text = LIPSUM
+
+
+body = FloatContainer(
+    content=HSplit([
+        Window(FormattedTextControl(
+                   'Press "q" to quit. Press "w" to enable/disable wrapping.'),
+               height=1, style='reverse'),
+        Window(BufferControl(buffer=buff), get_line_prefix=get_line_prefix,
+               wrap_lines=Condition(lambda: wrap_lines)),
+    ]),
+    floats=[
+        Float(xcursor=True,
+              ycursor=True,
+              content=CompletionsMenu(max_height=16, scroll_offset=1))
+    ]
+)
+
+
+# Key bindings
+kb = KeyBindings()
+
+
+@kb.add('q')
+@kb.add('c-c')
+def _(event):
+    " Quit application. "
+    event.app.exit()
+
+@kb.add('w')
+def _(event):
+    " Disable/enable wrapping. "
+    global wrap_lines
+    wrap_lines = not wrap_lines
+
+
+# The `Application`
+application = Application(
+    layout=Layout(body),
+    key_bindings=kb,
+    full_screen=True,
+    mouse_support=True)
+
+
+def run():
+    application.run()
+
+
+if __name__ == '__main__':
+    run()

--- a/examples/prompts/get-multiline-input.py
+++ b/examples/prompts/get-multiline-input.py
@@ -4,15 +4,18 @@ from prompt_toolkit import prompt
 from prompt_toolkit.formatted_text import HTML
 
 
-def prompt_continuation(width, line_number, is_soft_wrap):
+def prompt_continuation(width, line_number, wrap_count):
     """
     The continuation: display line numbers and '->' before soft wraps.
 
     Notice that we can return any kind of formatted text from here.
+
+    The prompt continuation doesn't have to be the same width as the prompt
+    which is displayed before the first line, but in this example we choose to
+    align them. The `width` input that we receive here represents the width of
+    the prompt.
     """
-    # (make sure that the width of the continuation does not exceed the given
-    # width. -- It is the prompt that determines the width of the left margin.)
-    if is_soft_wrap:
+    if wrap_count > 0:
         return ' ' * (width - 3) + '-> '
     else:
         text = ('- %i - ' % (line_number + 1)).rjust(width)

--- a/prompt_toolkit/layout/controls.py
+++ b/prompt_toolkit/layout/controls.py
@@ -48,7 +48,7 @@ class UIControl(with_metaclass(ABCMeta, object)):
     def preferred_width(self, max_available_width):
         return None
 
-    def preferred_height(self, width, max_available_height, wrap_lines):
+    def preferred_height(self, width, max_available_height, wrap_lines, get_line_prefix):
         return None
 
     def is_focusable(self):
@@ -131,8 +131,8 @@ class UIContent(object):
         self.menu_position = menu_position
         self.show_cursor = show_cursor
 
-        # Cache for line heights. Maps (lineno, width) -> height.
-        self._line_heights = {}
+        # Cache for line heights. Maps (lineno, width) -> (height, fragments).
+        self._line_heights_and_fragments = {}
 
     def __getitem__(self, lineno):
         " Make it iterable (iterate line by line). "
@@ -141,37 +141,71 @@ class UIContent(object):
         else:
             raise IndexError
 
-    def get_height_for_line(self, lineno, width):
+    def get_height_for_line(self, lineno, width, get_line_prefix):
         """
         Return the height that a given line would need if it is rendered in a
-        space with the given width.
+        space with the given width (using line wrapping).
+
+        :param get_line_prefix: None or a `Window.get_line_prefix` callable
+            that returns the prefix to be inserted before this line.
         """
+        return self.wrap_line(lineno, width, get_line_prefix)[0]
+
+    def wrap_line(self, lineno, width, get_line_prefix, slice_stop=None):
+        """
+        :param slice_stop: Wrap only "line[:slice_stop]" and return that
+            partial result. This is needed for scrolling the window correctly
+            when line wrapping.
+        :returns: A tuple `(height, computed_fragment_list)`.
+        """
+            # TODO: If no prefix is given, use the fast path
+            #       that we had before.
+        if get_line_prefix is None:
+            get_line_prefix = lambda *a: []
+
+        # Instead of using `get_line_prefix` as key, we use render_counter
+        # instead. This is more reliable, because this function could still be
+        # the same, while the content would change over time.
+        key = get_app().render_counter, lineno, width, slice_stop
+
         try:
-            return self._line_heights[lineno, width]
+            return self._line_heights_and_fragments[key]
         except KeyError:
-            text = fragment_list_to_text(self.get_line(lineno))
-            result = self.get_height_for_text(text, width)
+            if width == 0:
+                height = 10 ** 8
+            else:
+                # Get line.
+                line = fragment_list_to_text(self.get_line(lineno))[:slice_stop]
+
+                # Start with this line + first prefix.
+                fragments = [('', line)]
+                fragments.extend(to_formatted_text(get_line_prefix(lineno, 0)))
+
+                # Calculate text width first.
+                text_width = get_cwidth(fragment_list_to_text(fragments))
+
+                # Keep wrapping as long as the line doesn't fit.
+                # Keep adding new prefixes for every wrapped line.
+                height = 1
+
+                while text_width > width:
+                    height += 1
+                    text_width -= width
+
+                    fragments2 = to_formatted_text(
+                        get_line_prefix(lineno, height - 1))
+                    fragments.extend(fragments2)
+                    prefix_width = get_cwidth(fragment_list_to_text(fragments2))
+
+                    if prefix_width > width:  # Prefix doesn't fit.
+                        height = 10 ** 8
+                        break
+
+                    text_width += prefix_width
 
             # Cache and return
-            self._line_heights[lineno, width] = result
-            return result
-
-    @staticmethod
-    def get_height_for_text(text, width):
-        # Get text width for this line.
-        line_width = get_cwidth(text)
-
-        # Calculate height.
-        try:
-            quotient, remainder = divmod(line_width, width)
-        except ZeroDivisionError:
-            # Return something very big.
-            # (This can happen, when the Window gets very small.)
-            return 10 ** 8
-        else:
-            if remainder:
-                quotient += 1  # Like math.ceil.
-            return max(1, quotient)
+            self._line_heights_and_fragments[key] = height, fragments
+            return height, fragments
 
 
 class FormattedTextControl(UIControl):
@@ -271,7 +305,7 @@ class FormattedTextControl(UIControl):
         line_lengths = [get_cwidth(l) for l in text.split('\n')]
         return max(line_lengths)
 
-    def preferred_height(self, width, max_available_height, wrap_lines):
+    def preferred_height(self, width, max_available_height, wrap_lines, get_line_prefix):
         content = self.create_content(width, None)
         return content.line_count
 
@@ -460,7 +494,7 @@ class BufferControl(UIControl):
         self._last_get_processed_line = None
 
     def __repr__(self):
-        return '<%s(buffer=%r at %r>' % (self.__class__.__name__, self.buffer, id(self))
+        return '<%s buffer=%r at %r>' % (self.__class__.__name__, self.buffer, id(self))
 
     @property
     def search_buffer_control(self):
@@ -508,7 +542,7 @@ class BufferControl(UIControl):
         """
         return None
 
-    def preferred_height(self, width, max_available_height, wrap_lines):
+    def preferred_height(self, width, max_available_height, wrap_lines, get_line_prefix):
         # Calculate the content height, if it was drawn on a screen with the
         # given width.
         height = 0
@@ -525,7 +559,7 @@ class BufferControl(UIControl):
             return max_available_height
 
         for i in range(content.line_count):
-            height += content.get_height_for_line(i, width)
+            height += content.get_height_for_line(i, width, get_line_prefix)
 
             if height >= max_available_height:
                 return max_available_height

--- a/prompt_toolkit/layout/margins.py
+++ b/prompt_toolkit/layout/margins.py
@@ -209,9 +209,17 @@ class ScrollbarMargin(Margin):
 
 class PromptMargin(Margin):
     """
+    [Deprecated]
+
     Create margin that displays a prompt.
     This can display one prompt at the first line, and a continuation prompt
     (e.g, just dots) on all the following lines.
+
+    This `PromptMargin` implementation has been largely superseded in favor of
+    the `get_line_prefix` attribute of `Window`. The reason is that a margin is
+    always a fixed width, while `get_line_prefix` can return a variable width
+    prefix in front of every line, making it more powerful, especially for line
+    continuations.
 
     :param get_prompt: Callable returns formatted text or a list of
         `(style_str, type)` tuples to be shown as the prompt at the first line.

--- a/prompt_toolkit/layout/menus.py
+++ b/prompt_toolkit/layout/menus.py
@@ -47,7 +47,8 @@ class CompletionsMenuControl(UIControl):
         else:
             return 0
 
-    def preferred_height(self, width, max_available_height, wrap_lines):
+    def preferred_height(self, width, max_available_height, wrap_lines,
+                         get_line_prefix):
         complete_state = get_app().current_buffer.complete_state
         if complete_state:
             return len(complete_state.completions)
@@ -262,7 +263,8 @@ class MultiColumnCompletionMenuControl(UIControl):
             result -= column_width
         return result + self._required_margin
 
-    def preferred_height(self, width, max_available_height, wrap_lines):
+    def preferred_height(self, width, max_available_height, wrap_lines,
+                         get_line_prefix):
         """
         Preferred height: as much as needed in order to display all the completions.
         """
@@ -534,7 +536,8 @@ class _SelectedCompletionMetaControl(UIControl):
         else:
             return 0
 
-    def preferred_height(self, width, max_available_height, wrap_lines):
+    def preferred_height(self, width, max_available_height, wrap_lines,
+                         get_line_prefix):
         return 1
 
     def create_content(self, width, height):

--- a/prompt_toolkit/layout/processors.py
+++ b/prompt_toolkit/layout/processors.py
@@ -393,6 +393,12 @@ class BeforeInput(Processor):
 
 
 class ShowArg(BeforeInput):
+    """
+    Display the 'arg' in front of the input.
+
+    This was used by the `PromptSession`, but now it uses the
+    `Window.get_line_prefix` function instead.
+    """
     def __init__(self):
         super(ShowArg, self).__init__(self._get_text_fragments)
 


### PR DESCRIPTION
This is a refactoring that opens up many possibilities.
- Line wrapping (soft or hard) can insert or remove whitespace in front of the
  line, or insert some symbols in front. Like the Vim "breakindentopt" option.
- Single line prompts also support line continuations now.
- Line continuations can have a variable width.