### PR TITLE
Don't restore editing_mode

### DIFF
--- a/prompt_toolkit/shortcuts/prompt.py
+++ b/prompt_toolkit/shortcuts/prompt.py
@@ -716,6 +716,7 @@ class PromptSession(object):
         def restore():
             " Restore original settings. "
             for name in self._fields:
+                if name == "editing_mode": continue
                 setattr(self, name, backup[name])
 
         def pre_run():


### PR DESCRIPTION
editing_mode is saved in Application which isn't a property of
PromptSession and shouldn't be restored.

This prevents that editing_mode is restored for the next prompt in
a PromptSession for pgcli/mycli where editing_mode is changed
by a key binding while PromptSession.prompt is being executed.