### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Some features:
 - Both Emacs and Vi key bindings. (Similar to readline.)
 - Even some advanced Vi functionality, like named registers and digraphs.
 - Reverse and forward incremental search.
-- Runs on all Python versions from 2.6 up to 3.6.
+- Runs on all Python versions from 2.6 up to 3.7.
 - Works well with Unicode double width characters. (Chinese input.)
 - Selecting text for copy/paste. (Both Emacs and Vi style.)
 - Support for `bracketed paste <https://cirw.in/blog/bracketed-paste>`_.

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Some features:
 - Both Emacs and Vi key bindings. (Similar to readline.)
 - Even some advanced Vi functionality, like named registers and digraphs.
 - Reverse and forward incremental search.
-- Runs on all Python versions from 2.6 up to 3.5.
+- Runs on all Python versions from 2.6 up to 3.6.
 - Works well with Unicode double width characters. (Chinese input.)
 - Selecting text for copy/paste. (Both Emacs and Vi style.)
 - Support for `bracketed paste <https://cirw.in/blog/bracketed-paste>`_.


### PR DESCRIPTION
Include Python 3.6 in readme.

Assuming true based on tests that have been running since last year.