### PR TITLE
Add license to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     name='prompt_toolkit',
     author='Jonathan Slenders',
     version=get_version('prompt_toolkit'),
+    license='BSD-3-Clause',
     url='https://github.com/jonathanslenders/python-prompt-toolkit',
     description='Library for building powerful interactive command lines in Python',
     long_description=long_description,


### PR DESCRIPTION
In order to make automatic checking of license compliance faster, add license to the setup arguments.