### PR TITLE
RadioList: pagedown/pageup support

### DIFF
--- a/prompt_toolkit/widgets/base.py
+++ b/prompt_toolkit/widgets/base.py
@@ -573,14 +573,35 @@ class RadioList(object):
         # Key bindings.
         kb = KeyBindings()
 
-        @kb.add('up')
+        @kb.add(Keys.Up)
         def _(event):
-            self._selected_index = max(0, self._selected_index - 1)
+            self._selected_index = max(
+                0,
+                self._selected_index - 1
+            )
 
-        @kb.add('down')
+        @kb.add(Keys.Down)
         def _(event):
             self._selected_index = min(
-                len(self.values) - 1, self._selected_index + 1)
+                len(self.values) - 1,
+                self._selected_index + 1
+            )
+
+        @kb.add(Keys.PageUp)
+        def _(event):
+            w = event.app.layout.current_window
+            self._selected_index = max(
+                0,
+                self._selected_index - len(w.render_info.displayed_lines)
+            )
+
+        @kb.add(Keys.PageDown)
+        def _(event):
+            w = event.app.layout.current_window
+            self._selected_index = min(
+                len(self.values) - 1,
+                self._selected_index + len(w.render_info.displayed_lines)
+            )
 
         @kb.add('enter')
         @kb.add(' ')


### PR DESCRIPTION
This PR:
- was part of https://github.com/jonathanslenders/python-prompt-toolkit/pull/758
- contains support for the PageUp / PageDown keys on RadioList